### PR TITLE
add thresh processor

### DIFF
--- a/monasca/common/alarm_expr_calculator.py
+++ b/monasca/common/alarm_expr_calculator.py
@@ -1,0 +1,87 @@
+# Copyright 2015 CMU
+# Author: Yihan Wang <wangff9@gmail.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+def calc_value(func, data_list):
+    """Calc float values according to 5 functions."""
+    ops = {'SUM': sum,
+           'AVG': lambda x: sum(x) / len(x),
+           'MAX': max,
+           'MIN': min,
+           'COUNT': len}
+    if len(data_list) == 0 or func not in ops:
+        return None
+    else:
+        return ops[func](data_list)
+
+
+def compare_thresh(values, op, thresh):
+    """Check if value from metrics exceeds thresh.
+
+    Only the value in each period meet thresh, the alarm state can be 'ALARM'.
+
+    For example, the alarm definition defines 3 periods, values = [a,b,c].
+    If the value in any period doesn't meet thresh,
+    then alarm state must be 'OK';
+    If some values are None (means no metrics in that period)
+    but all other values meet thresh,
+    we still don't know if the alarm can be triggered,
+    so it's 'UNDETERMINED';
+    otherwise, the state can be 'ALARM'
+    """
+
+    state = 'OK'
+    for value in values:
+        if value:
+            if op == 'GT' and value <= thresh:
+                return state
+            elif op == 'LT' and value >= thresh:
+                return state
+            elif op == 'LTE' and value > thresh:
+                return state
+            elif op == 'GTE' and value < thresh:
+                return state
+    state = 'ALARM'
+    for value in values:
+        if value is None:
+            state = 'UNDETERMINED'
+    return state
+
+
+def calc_logic(logic_operator, subs):
+    """Calc overall state of an alarm expression.
+
+    'OK' means False;
+    'ALARM' means True;
+    'UNDETERMINED' means either True or False.
+    """
+    if logic_operator == 'AND':
+        for o in subs:
+            if o == 'OK':
+                return 'OK'
+        for o in subs:
+            if o == 'UNDETERMINED':
+                return 'UNDETERMINED'
+        return 'ALARM'
+    elif logic_operator == 'OR':
+        for o in subs:
+            if o == 'ALARM':
+                return 'ALARM'
+        for o in subs:
+            if o == 'UNDETERMINED':
+                return 'UNDETERMINED'
+        return 'OK'
+    else:
+        return 'UNDETERMINED'

--- a/monasca/common/alarm_expr_calculator.py
+++ b/monasca/common/alarm_expr_calculator.py
@@ -68,20 +68,20 @@ def calc_logic(logic_operator, subs):
     'UNDETERMINED' means either True or False.
     """
     if logic_operator == 'AND':
+        state = 'ALARM'
         for o in subs:
             if o == 'OK':
                 return 'OK'
-        for o in subs:
-            if o == 'UNDETERMINED':
-                return 'UNDETERMINED'
-        return 'ALARM'
+            elif o == 'UNDETERMINED':
+                state = 'UNDETERMINED'
+        return state
     elif logic_operator == 'OR':
+        state = 'OK'
         for o in subs:
             if o == 'ALARM':
                 return 'ALARM'
-        for o in subs:
-            if o == 'UNDETERMINED':
-                return 'UNDETERMINED'
-        return 'OK'
+            elif o == 'UNDETERMINED':
+                state = 'UNDETERMINED'
+        return state
     else:
         return 'UNDETERMINED'

--- a/monasca/common/alarm_expr_parser.py
+++ b/monasca/common/alarm_expr_parser.py
@@ -95,11 +95,6 @@ class SubExpr(object):
         return self._metric_name.lower()
 
     @property
-    def dimensions(self):
-        """Get the dimensions."""
-        return self._dimensions
-
-    @property
     def dimensions_as_list(self):
         """Get the dimensions as a list."""
         if self._dimensions:
@@ -280,14 +275,46 @@ expression = (
 class AlarmExprParser(object):
     def __init__(self, expr):
         self._expr = expr
-        # Remove all spaces before parsing. Simple, quick fix for whitespace
-        # issue with dimension list not allowing whitespace after comma.
+        try:
+            self.parseResult = (expression + pyparsing.stringEnd).parseString(
+                self._expr.replace(' ', ''))[0]
+        except Exception:
+            self.parseResult = None
 
     @property
     def parse_result(self):
-        try:
-            parseResult = (expression + pyparsing.stringEnd).parseString(
-                self._expr.replace(' ', ''))
-            return parseResult[0]
-        except Exception:
+        return self.parseResult
+
+    @property
+    def sub_expr_list(self):
+        if self.parseResult:
+            return self.parseResult.operands_list
+        else:
             return None
+
+    @property
+    def related_metrics(self):
+        """Get a list of all the metrics related with this expression."""
+        related_metrics = []
+        for expr in self.sub_expr_list:
+            related_metrics.append({
+                'name': expr.metric_name,
+                'dimensions': expr.dimensions_as_dict
+            })
+        return related_metrics
+
+    @property
+    def sub_alarm_expressions(self):
+        """Get a list of all the sub expr parsed information."""
+        sub_alarm_expr = {}
+        for expr in self.sub_expr_list:
+            sub_alarm_expr[expr.fmtd_sub_expr_str] = {
+                'function': expr.normalized_func,
+                'metric_name': expr.normalized_metric_name,
+                'dimensions': expr.dimensions_as_dict,
+                'operator': expr.normalized_operator,
+                'threshold': expr.threshold,
+                'period': expr.period,
+                'periods': expr.periods
+            }
+        return sub_alarm_expr

--- a/monasca/microservice/thresholding_processor.py
+++ b/monasca/microservice/thresholding_processor.py
@@ -209,8 +209,7 @@ class ThresholdingProcessor(object):
         """Add new metrics to sub expr place."""
 
         def _has_match_expr():
-            if (data['name'].lower().encode('utf8') !=
-                    expr.normalized_metric_name.encode('utf8')):
+            if (data['name'].lower() != expr.normalized_metric_name):
                 return False
             metrics_dimensions = {}
             if 'dimensions' in data:
@@ -218,10 +217,8 @@ class ThresholdingProcessor(object):
             def_dimensions = expr.dimensions_as_dict
             for dimension_key in def_dimensions.keys():
                 if dimension_key in metrics_dimensions:
-                    if (metrics_dimensions[
-                            dimension_key].lower().encode('utf8')
-                            != def_dimensions[
-                            dimension_key].lower().encode('utf8')):
+                    if (metrics_dimensions[dimension_key].lower()
+                            != def_dimensions[dimension_key].lower()):
                         return False
                 else:
                     return False

--- a/monasca/microservice/thresholding_processor.py
+++ b/monasca/microservice/thresholding_processor.py
@@ -1,0 +1,309 @@
+# Copyright 2015 CMU
+# Author: Yihan Wang <wangff9@gmail.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import collections
+import json
+from monasca.common import alarm_expr_calculator as calculator
+from monasca.common import alarm_expr_parser as parser
+from monasca.openstack.common import log
+from monasca.openstack.common import timeutils as tu
+import time
+import uuid
+
+
+LOG = log.getLogger(__name__)
+
+
+class ThresholdingProcessor(object):
+    def __init__(self, alarm_def):
+        """One processor instance hold one alarm definition."""
+        LOG.debug('initializing ThresholdProcessor!')
+        super(ThresholdingProcessor, self).__init__()
+        self.alarm_definition = json.loads(alarm_def)
+        self.expression = self.alarm_definition['expression']
+        self.match_by = self.alarm_definition['match_by']
+        self.expr_data_queue = {}
+        self.related_metrics = {}
+        if len(self.match_by) == 0:
+            self.match_by = None
+        alarm_parser = parser.AlarmExprParser(self.expression)
+        self.parse_result = alarm_parser.parse_result
+        self.sub_expr_list = alarm_parser.sub_expr_list
+        self.related_metrics[None] = alarm_parser.related_metrics
+        self.sub_alarm_expr = alarm_parser.sub_alarm_expressions
+        LOG.debug('successfully initialize ThresholdProcessor!')
+
+    def update_thresh_processor(self, alarm_def):
+        def update_data():
+            for name in self.expr_data_queue:
+                ts = tu.utcnow_ts()
+                new_expr_data_queue[name] = {
+                    'data': {},
+                    'state': 'UNDETERMINED',
+                    'create_timestamp':
+                        self.expr_data_queue[name]['create_timestamp'],
+                    'update_timestamp': ts,
+                    'state_update_timestamp':
+                        self.expr_data_queue[name]['state_update_timestamp']
+                }
+                for i in range(0, len(new_sub_expr_list), 1):
+                    expr_old = self.sub_expr_list[i].fmtd_sub_expr_str
+                    expr_new = new_sub_expr_list[i].fmtd_sub_expr_str
+                    new_expr_data_queue[name]['data'][expr_new] = {
+                        'state': 'UNDETERMINED',
+                        'metrics':
+                            (self.expr_data_queue[name]
+                             ['data'][expr_old]['metrics']),
+                        'values': []}
+
+        def check_legal_update():
+            l = len(self.sub_expr_list)
+            if not new_sub_expr_list or l != len(new_sub_expr_list):
+                return False
+            for i in range(0, l, 1):
+                expr_old = self.sub_expr_list[i]
+                expr_new = new_sub_expr_list[i]
+                if (expr_old.normalized_metric_name
+                        != expr_new.normalized_metric_name):
+                    return False
+                if (expr_old.dimensions_as_dict
+                        != expr_new.dimensions_as_dict):
+                    return False
+            return True
+
+        LOG.debug('update ThresholdProcessor!')
+        new_alarm_definition = json.loads(alarm_def)
+        new_expression = new_alarm_definition['expression']
+        alarm_parser = parser.AlarmExprParser(new_expression)
+        new_sub_expr_list = alarm_parser.sub_expr_list
+        new_expr_data_queue = {}
+        if not check_legal_update():
+            LOG.debug('illegal thresh processor update')
+            return False
+        update_data()
+        self.expr_data_queue = new_expr_data_queue
+        self.sub_expr_list = new_sub_expr_list
+        self.sub_alarm_expr = alarm_parser.sub_alarm_expressions
+        self.parse_result = alarm_parser.parse_result
+        self.alarm_definition = new_alarm_definition
+        self.expression = new_expression
+        self.match_by = self.alarm_definition['match_by']
+        if len(self.match_by) == 0:
+            self.match_by = None
+        LOG.debug('successfully update ThresholdProcessor!')
+        return True
+
+    def process_metrics(self, metrics):
+        """Add new metrics to matched expr."""
+        try:
+            data = json.loads(metrics)
+            self.add_expr_metrics(data)
+        except Exception:
+            LOG.exception('Received a wrong format metrics')
+
+    def process_alarms(self):
+        """Run every minute to produce alarm."""
+        try:
+            alarm_list = []
+            for m in self.expr_data_queue.keys():
+                is_updated = self.update_state(self.expr_data_queue[m])
+                if is_updated:
+                    alarm_list.append(self.build_alarm(m))
+            return alarm_list
+        except Exception:
+            LOG.exception('process metrics error')
+            return []
+
+    def update_state(self, expr_data):
+        """Update the state of each alarm under this alarm definition."""
+
+        def _calc_state(operand):
+            if operand.logic_operator:
+                subs = []
+                for o in operand.sub_expr_list:
+                    subs.append(_calc_state(o))
+                return calculator.calc_logic(operand.logic_operator, subs)
+            else:
+                return expr_data['data'][operand.fmtd_sub_expr_str]['state']
+
+        for sub_expr in self.sub_expr_list:
+            self.update_sub_expr_state(sub_expr, expr_data)
+        state_new = _calc_state(self.parse_result)
+        if state_new != expr_data['state']:
+            expr_data['state_update_timestamp'] = tu.utcnow_ts()
+            expr_data['update_timestamp'] = tu.utcnow_ts()
+            expr_data['state'] = state_new
+            return True
+        else:
+            return False
+
+    def update_sub_expr_state(self, expr, expr_data):
+        def _update_metrics():
+            """Delete metrics not in period."""
+            data_list = expr_data['data'][expr.fmtd_sub_expr_str]['metrics']
+            start_time = t_now - (float(expr.period) + 2) * int(expr.periods)
+            while (len(data_list) != 0
+                   and data_list[0]['timestamp'] < start_time):
+                data_list.popleft()
+
+        def _update_state():
+            """Update state of a sub expr."""
+            data_sub = expr_data['data'][expr.fmtd_sub_expr_str]
+            data_list = data_sub['metrics']
+            if len(data_list) == 0:
+                data_sub['state'] = 'UNDETERMINED'
+            else:
+                period = float(expr.period)
+                periods = int(expr.periods)
+                right = t_now
+                left = right - period
+                temp_data = []
+                value_in_periods = []
+                for i in range(len(data_list) - 1, -1, -1):
+                    if data_list[i]['timestamp'] >= left:
+                        temp_data.append(float(data_list[i]['value']))
+                    else:
+                        value = calculator.calc_value(
+                            expr.normalized_func, temp_data)
+                        value_in_periods.append(value)
+                        right = left
+                        left = right - period
+                        temp_data = []
+                value = calculator.calc_value(
+                    expr.normalized_func, temp_data)
+                value_in_periods.append(value)
+                for i in range(len(value_in_periods), periods, 1):
+                    value_in_periods.append(None)
+                expr_data['data'][expr.fmtd_sub_expr_str]['values'] = (
+                    value_in_periods)
+                expr_data['data'][expr.fmtd_sub_expr_str]['state'] = (
+                    calculator.compare_thresh(
+                        value_in_periods,
+                        expr.normalized_operator,
+                        float(expr.threshold)))
+
+        t_now = tu.iso8601_from_timestamp(tu.utcnow_ts())
+        t_now = tu.parse_isotime(t_now).timetuple()
+        t_now = time.mktime(t_now)
+        _update_metrics()
+        _update_state()
+
+    def add_expr_metrics(self, data):
+        """Add new metrics to matched place."""
+        for sub_expr in self.sub_expr_list:
+            self.add_sub_expr_metrics(sub_expr, data)
+
+    def add_sub_expr_metrics(self, expr, data):
+        """Add new metrics to sub expr place."""
+
+        def _has_match_expr():
+            if (data['name'].lower().encode('utf8') !=
+                    expr.normalized_metric_name.encode('utf8')):
+                return False
+            metrics_dimensions = {}
+            if 'dimensions' in data:
+                metrics_dimensions = data['dimensions']
+            def_dimensions = expr.dimensions_as_dict
+            for dimension_key in def_dimensions.keys():
+                if dimension_key in metrics_dimensions:
+                    if (metrics_dimensions[
+                            dimension_key].lower().encode('utf8')
+                            != def_dimensions[
+                            dimension_key].lower().encode('utf8')):
+                        return False
+                else:
+                    return False
+            return True
+
+        def _add_metrics():
+            temp = None
+            if self.match_by:
+                q_name = self.get_matched_data_queue_name(data)
+                if q_name:
+                    temp = self.expr_data_queue[q_name]
+            else:
+                if None not in self.expr_data_queue:
+                    self.create_data_item(None)
+                temp = self.expr_data_queue[None]
+            if temp:
+                data_list = temp['data'][expr.fmtd_sub_expr_str]
+                data_list['metrics'].append(
+                    {'value': float(data['value']),
+                     'timestamp':
+                         time.mktime(tu.parse_isotime(
+                             data['timestamp']).timetuple())})
+
+        if _has_match_expr():
+            _add_metrics()
+
+    def create_data_item(self, name):
+        """If not exist in dict, create one item."""
+        ts = tu.utcnow_ts()
+        self.expr_data_queue[name] = {
+            'data': {},
+            'state': 'UNDETERMINED',
+            'create_timestamp': ts,
+            'update_timestamp': ts,
+            'state_update_timestamp': ts}
+        for expr in self.sub_expr_list:
+            self.expr_data_queue[name]['data'][expr.fmtd_sub_expr_str] = {
+                'state': 'UNDETERMINED',
+                'metrics': collections.deque(),
+                'values': []}
+
+    def get_matched_data_queue_name(self, data):
+        name = ''
+        for m in self.match_by:
+            if m in data['dimensions']:
+                name = name + data['dimensions'][m] + ','
+            else:
+                return None
+        if name in self.expr_data_queue:
+            return name
+        else:
+            self.related_metrics[name] = []
+            for m in self.related_metrics[None]:
+                temp = m.copy()
+                for match in self.match_by:
+                    temp['dimensions'][match] = data['dimensions'][match]
+                self.related_metrics[name].append(temp)
+            self.create_data_item(name)
+            return name
+
+    def build_alarm(self, name):
+        """Build alarm json."""
+        alarm = {}
+        id = str(uuid.uuid4())
+        alarm['id'] = id
+        alarm['alarm-definition'] = self.alarm_definition
+        alarm['metrics'] = self.related_metrics[name]
+        alarm['state'] = self.expr_data_queue[name]['state']
+        sub_alarms = []
+        dt = self.expr_data_queue[name]['data']
+        for expr in self.sub_expr_list:
+            sub_alarms.append({
+                'sub_alarm_expression':
+                    self.sub_alarm_expr[expr.fmtd_sub_expr_str],
+                'sub_alarm_state': dt[expr.fmtd_sub_expr_str]['state'],
+                'current_values': dt[expr.fmtd_sub_expr_str]['values']
+            })
+        alarm['sub_alarms'] = sub_alarms
+        ct = self.expr_data_queue[name]['create_timestamp']
+        st = self.expr_data_queue[name]['state_update_timestamp']
+        t = self.expr_data_queue[name]['update_timestamp']
+        alarm['state_updated_timestamp'] = tu.iso8601_from_timestamp(st)
+        alarm['updated_timestamp'] = tu.iso8601_from_timestamp(t)
+        alarm['created_timestamp'] = tu.iso8601_from_timestamp(ct)
+        return json.dumps(alarm)

--- a/monasca/tests/common/test_alarm_expr_calculator.py
+++ b/monasca/tests/common/test_alarm_expr_calculator.py
@@ -1,0 +1,79 @@
+# Copyright 2015 CMU
+# Author: Yihan Wang <wangff9@gmail.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from monasca.common import alarm_expr_calculator as calculator
+from monasca.openstack.common import log
+from monasca import tests
+import random
+import time
+
+
+LOG = log.getLogger(__name__)
+
+
+class TestAlarmExprCalculator(tests.BaseTestCase):
+    def setUp(self):
+        super(TestAlarmExprCalculator, self).setUp()
+
+    def test_calc_value(self):
+        self.assertEqual(0, calculator.calc_value('MAX', [0]))
+        data = []
+        self.assertEqual(None, calculator.calc_value('MAX', data))
+        random.seed(time.time())
+        for i in range(0, 30, 1):
+            data.append(random.uniform(0, 1000))
+        self.assertEqual(max(data), calculator.calc_value('MAX', data))
+        self.assertEqual(sum(data), calculator.calc_value('SUM', data))
+        self.assertEqual(len(data), calculator.calc_value('COUNT', data))
+        self.assertEqual(min(data), calculator.calc_value('MIN', data))
+        self.assertEqual(sum(data) / len(data),
+                         calculator.calc_value('AVG', data))
+
+    def test_compare_thresh(self):
+        values = [501, 500, 4999]
+        op = 'GTE'
+        thresh = 500
+        self.assertEqual('ALARM',
+                         calculator.compare_thresh(values, op, thresh))
+        op = 'GT'
+        thresh = 500
+        self.assertEqual('OK', calculator.compare_thresh(values, op, thresh))
+        values = [501, 500, 4999, None]
+        op = 'LTE'
+        thresh = 5000
+        self.assertEqual('UNDETERMINED',
+                         calculator.compare_thresh(values, op, thresh))
+        values = [501, 500, 4999, None]
+        op = 'LT'
+        thresh = 4999
+        self.assertEqual('OK', calculator.compare_thresh(values, op, thresh))
+
+    def test_calc_logic(self):
+        op = 'AND'
+        subs = ['ALARM', 'OK', 'ALARM', 'UNDETERMINED']
+        self.assertEqual('OK', calculator.calc_logic(op, subs))
+        subs = ['ALARM', 'UNDETERMINED', 'ALARM', 'UNDETERMINED']
+        self.assertEqual('UNDETERMINED', calculator.calc_logic(op, subs))
+        subs = ['ALARM', 'ALARM', 'ALARM']
+        self.assertEqual('ALARM', calculator.calc_logic(op, subs))
+        op = 'OR'
+        subs = ['ALARM', 'OK', 'ALARM', 'UNDETERMINED']
+        self.assertEqual('ALARM', calculator.calc_logic(op, subs))
+        subs = ['UNDETERMINED', 'OK', 'UNDETERMINED']
+        self.assertEqual('UNDETERMINED', calculator.calc_logic(op, subs))
+        subs = ['OK', 'OK', 'OK']
+        self.assertEqual('OK', calculator.calc_logic(op, subs))
+        op = 'NOT'
+        self.assertEqual('UNDETERMINED', calculator.calc_logic(op, subs))

--- a/monasca/tests/common/test_alarm_expr_parser.py
+++ b/monasca/tests/common/test_alarm_expr_parser.py
@@ -52,6 +52,10 @@ class TestAlarmExprParser(tests.BaseTestCase):
 
         self.expr7 = "(max(foo)>=100 times 10"
 
+        self.expr8 = ("max(foo,me{hostname=mini-mon,千=千}, 120)"
+                      " = 100 and (max(bar)>100 "
+                      " or max(biz)>100)".decode('utf8'))
+
     def setUp(self):
         super(TestAlarmExprParser, self).setUp()
 
@@ -79,6 +83,9 @@ class TestAlarmExprParser(tests.BaseTestCase):
         self.assertEqual(u'AND', expr.logic_operator)
         self.assertEqual('OR', expr.sub_expr_list[1].logic_operator)
         self.assertEqual(None, expr.sub_expr_list[0].logic_operator)
+        self.assertEqual(
+            'max(foo{hostname=mini-mon,千=千}, 120) > 100'.decode('utf8'),
+            expr.sub_expr_list[0].fmtd_sub_expr_str)
 
         expr = alarm_expr_parser.AlarmExprParser(self.expr2).parse_result
         self.assertEqual(None, expr.logic_operator)
@@ -122,13 +129,33 @@ class TestAlarmExprParser(tests.BaseTestCase):
         expr = alarm_expr_parser.AlarmExprParser(self.expr2).parse_result
         self.assertEqual(10, int(expr.periods))
 
+    def test_period(self):
+        expr = alarm_expr_parser.AlarmExprParser(self.expr1).parse_result
+        self.assertEqual(60, int(expr.sub_expr_list[1].
+                                 sub_expr_list[1].period.encode('utf8')))
+
     def test_operator(self):
         expr = alarm_expr_parser.AlarmExprParser(self.expr1).parse_result
         self.assertEqual('GT', expr.sub_expr_list[1].
                          sub_expr_list[1].normalized_operator.encode('utf8'))
 
         expr = alarm_expr_parser.AlarmExprParser(self.expr2).parse_result
-        self.assertEqual('GTE', expr.normalized_operator)
+        self.assertEqual('>=', expr.operator)
+
+    def test_metric_name(self):
+        expr = alarm_expr_parser.AlarmExprParser(self.expr1).parse_result
+        self.assertEqual('biz', expr.sub_expr_list[1].
+                         sub_expr_list[1].metric_name.encode('utf8'))
+
+    def test_dimensions_str(self):
+        expr = alarm_expr_parser.AlarmExprParser(self.expr2).parse_result
+        temp = expr.dimensions_str
+        self.assertEqual('', temp)
+
+    def test_sub_expr_list(self):
+        expr = alarm_expr_parser.AlarmExprParser(self.expr2).parse_result
+        temp = expr.sub_expr_list
+        self.assertEqual([], temp)
 
     def test_dimensions_list(self):
         expr = alarm_expr_parser.AlarmExprParser(self.expr0).parse_result
@@ -153,3 +180,25 @@ class TestAlarmExprParser(tests.BaseTestCase):
 
         expr = alarm_expr_parser.AlarmExprParser(self.expr2).parse_result
         self.assertEqual({}, expr.dimensions_as_dict)
+
+    def test_related_metrics(self):
+        rm = alarm_expr_parser.AlarmExprParser(self.expr2).related_metrics
+        e_result = []
+        e_result.append({
+            'name': 'foo',
+            'dimensions': {}
+        })
+        self.assertEqual(e_result, rm)
+        rm = alarm_expr_parser.AlarmExprParser(self.expr1).related_metrics
+        self.assertEqual(3, len(rm))
+
+    def test_sub_alarm_expressions(self):
+        sae = (alarm_expr_parser.AlarmExprParser(self.expr1).
+               sub_alarm_expressions)
+        print (sae)
+        self.assertEqual(3, len(sae))
+
+    def test_wrong_format_expr(self):
+        sub_expr_list = (alarm_expr_parser.AlarmExprParser(self.expr8).
+                         sub_expr_list)
+        self.assertEqual(None, sub_expr_list)

--- a/monasca/tests/microservice/test_thresholding_processor.py
+++ b/monasca/tests/microservice/test_thresholding_processor.py
@@ -1,0 +1,683 @@
+# -*- coding: utf-8 -*-
+# Copyright 2015 CMU
+# Author: Yihan Wang <wangff9@gmail.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import json
+from monasca.microservice import thresholding_processor as processor
+from monasca.openstack.common import log
+from monasca.openstack.common import timeutils as tu
+from monasca import tests
+
+LOG = log.getLogger(__name__)
+
+
+class TestThresholdingProcessor(tests.BaseTestCase):
+    def __init__(self, *args, **kwargs):
+        super(TestThresholdingProcessor, self).__init__(*args, **kwargs)
+        self.alarm_definition0 = json.dumps({
+            "id": "f9935bcc-9641-4cbf-8224-0993a947ea83",
+            "name": "Average CPU percent greater than 10",
+            "description":
+                "The average CPU percent is greater than 10",
+            "expression":
+                "max(-_.千幸福的笑脸{घोड़ा=馬,  "
+                "dn2=dv2,"
+                "千幸福的笑脸घ=千幸福的笑脸घ}) gte 100 "
+                "times 1 And "
+                "(min(ເຮືອນ{dn3=dv3,家=дом}) < 10 "
+                "or sum(biz{dn5=dv58}) >9 9and "
+                "count(fizzle) lt 0 or count(baz) > 1)",
+            "match_by": [],
+            "severity": "LOW",
+            "ok_actions": [
+                "c60ec47e-5038-4bf1-9f95-4046c6e9a759"
+            ],
+            "alarm_actions": [
+                "c60ec47e-5038-4bf1-9f95-4046c6e9a759"
+            ],
+            "undetermined_actions": [
+                "c60ec47e-5038-4bf1-9f95-4046c6e9a759"
+            ]})
+        self.alarm_definition1 = json.dumps({
+            "id": "f9935bcc-9641-4cbf-8224-0993a947ea83",
+            "name": "Average CPU percent greater than 10",
+            "description":
+                "The average CPU percent is greater than 10",
+            "expression": "max(biz{key2=value2})>1400",
+            "match_by": [
+                "hostname"
+            ],
+            "severity": "LOW",
+            "ok_actions": [
+                "c60ec47e-5038-4bf1-9f95-4046c6e9a759"
+            ],
+            "alarm_actions": [
+                "c60ec47e-5038-4bf1-9f95-4046c6e9a759"
+            ],
+            "undetermined_actions": [
+                "c60ec47e-5038-4bf1-9f95-4046c6e9a759"
+            ]})
+        self.alarm_definition1_update = json.dumps({
+            "id": "f9935bcc-9641-4cbf-8224-0993a947ea83",
+            "name": "Average CPU percent greater than 10",
+            "description":
+                "The average CPU percent is greater than 10",
+            "expression": "min(biz{key2=value2})<1450",
+            "match_by": [
+                "hostname"
+            ],
+            "severity": "LOW",
+            "ok_actions": [
+                "c60ec47e-5038-4bf1-9f95-4046c6e9a759"
+            ],
+            "alarm_actions": [
+                "c60ec47e-5038-4bf1-9f95-4046c6e9a759"
+            ],
+            "undetermined_actions": [
+                "c60ec47e-5038-4bf1-9f95-4046c6e9a759"
+            ]})
+        self.alarm_definition1_update_wrong1 = json.dumps({
+            "id": "f9935bcc-9641-4cbf-8224-0993a947ea83",
+            "name": "Average CPU percent greater than 10",
+            "description":
+                "The average CPU percent is greater than 10",
+            "expression": "min(biz{key2=value1})<1450",
+            "match_by": [
+                "hostname"
+            ],
+            "severity": "LOW",
+            "ok_actions": [
+                "c60ec47e-5038-4bf1-9f95-4046c6e9a759"
+            ],
+            "alarm_actions": [
+                "c60ec47e-5038-4bf1-9f95-4046c6e9a759"
+            ],
+            "undetermined_actions": [
+                "c60ec47e-5038-4bf1-9f95-4046c6e9a759"
+            ]})
+        self.alarm_definition1_update_wrong2 = json.dumps({
+            "id": "f9935bcc-9641-4cbf-8224-0993a947ea83",
+            "name": "Average CPU percent greater than 10",
+            "description":
+                "The average CPU percent is greater than 10",
+            "expression": "min(bi{key2=value2})<1450",
+            "match_by": [
+                "hostname"
+            ]})
+        self.alarm_definition1_update_wrong3 = json.dumps({
+            "id": "f9935bcc-9641-4cbf-8224-0993a947ea83",
+            "name": "Average CPU percent greater than 10",
+            "description":
+                "The average CPU percent is greater than 10",
+            "expression": "min(biz{key2=value2})"
+                          "<1450 and max(bi{})<60 times 20)",
+            "match_by": [
+                "hostname"
+            ]})
+        self.alarm_definition4 = json.dumps({
+            "id": "f9935bcc-9641-4cbf-8224-0993a947ea83",
+            "name": "Average CPU percent greater than 10",
+            "description":
+                "The average CPU percent is greater than 10",
+            "expression": "avg(biz{key2=value2})>1400",
+            "match_by": [
+                "hostname"
+            ],
+            "severity": "LOW",
+            "ok_actions": [
+                "c60ec47e-5038-4bf1-9f95-4046c6e9a759"
+            ],
+            "alarm_actions": [
+                "c60ec47e-5038-4bf1-9f95-4046c6e9a759"
+            ],
+            "undetermined_actions": [
+                "c60ec47e-5038-4bf1-9f95-4046c6e9a759"
+            ]})
+        self.alarm_definition2 = json.dumps({
+            "id": "f9935bcc-9641-4cbf-8224-0993a947ea83",
+            "name": "Average CPU percent greater than 10",
+            "description":
+                "The average CPU percent is greater than 10",
+            "expression": "max(foo)>=100 times 4",
+            "match_by": [],
+            "severity": "LOW",
+            "ok_actions": [
+                "c60ec47e-5038-4bf1-9f95-4046c6e9a759"
+            ],
+            "alarm_actions": [
+                "c60ec47e-5038-4bf1-9f95-4046c6e9a759"
+            ],
+            "undetermined_actions": [
+                "c60ec47e-5038-4bf1-9f95-4046c6e9a759"
+            ]})
+        self.alarm_definition2_update = json.dumps({
+            "id": "f9935bcc-9641-4cbf-8224-0993a947ea83",
+            "name": "Average CPU percent greater than 10",
+            "description":
+                "The average CPU percent is greater than 10",
+            "expression": "max(foo,80)>=100 times 6",
+            "match_by": [],
+            "severity": "LOW",
+            "ok_actions": [
+                "c60ec47e-5038-4bf1-9f95-4046c6e9a759"
+            ],
+            "alarm_actions": [
+                "c60ec47e-5038-4bf1-9f95-4046c6e9a759"
+            ],
+            "undetermined_actions": [
+                "c60ec47e-5038-4bf1-9f95-4046c6e9a759"
+            ]})
+        self.alarm_definition3 = json.dumps({
+            "id": "f9935bcc-9641-4cbf-8224-0993a947ea83",
+            "name": "Average CPU percent greater than 10",
+            "description":
+                "The average CPU percent is greater than 10",
+            "expression": "max(foo{hostname=mini-mon"
+                          ",千=千}, 120)"
+                          " = 100 and (max(bar)>100 "
+                          " or max(biz)>100)",
+            "match_by": [],
+            "severity": "LOW",
+            "ok_actions": [
+                "c60ec47e-5038-4bf1-9f95-4046c6e9a759"
+            ],
+            "alarm_actions": [
+                "c60ec47e-5038-4bf1-9f95-4046c6e9a759"
+            ],
+            "undetermined_actions": [
+                "c60ec47e-5038-4bf1-9f95-4046c6e9a759"
+            ]})
+        self.alarm_definition5 = json.dumps({
+            "id": "f9935bcc-9641-4cbf-8224-0993a947ea83",
+            "name": "Average CPU percent greater than 10",
+            "description":
+                "The average CPU percent is greater than 10",
+            "expression": "avg(biz{key2=value2})>1400",
+            "match_by": [
+                "hostname",
+                "system"
+            ],
+            "severity": "LOW",
+            "ok_actions": [
+                "c60ec47e-5038-4bf1-9f95-4046c6e9a759"
+            ],
+            "alarm_actions": [
+                "c60ec47e-5038-4bf1-9f95-4046c6e9a759"
+            ],
+            "undetermined_actions": [
+                "c60ec47e-5038-4bf1-9f95-4046c6e9a759"
+            ]})
+
+    def get_metric2_0(self):
+        list = []
+        for i in range(0, 10, 1):
+            metrics = {"name": "foo",
+                       "dimensions": {
+                           "key1": "value1",
+                           "key2": "value2"
+                       },
+                       "timestamp":
+                           tu.iso8601_from_timestamp(
+                               tu.utcnow_ts() + i * 20 - 140),
+                       "value": i * 10}
+            list.append(json.dumps(metrics))
+        return list
+
+    def get_metric2_1(self):
+        list = []
+        for i in range(10, 30, 1):
+            metrics = {"name": "foo",
+                       "dimensions": {
+                           "key1": "value1",
+                           "key2": "value2"
+                       },
+                       "timestamp":
+                           tu.iso8601_from_timestamp(
+                               tu.utcnow_ts() + i * 20 - 570),
+                       "value": i * 75}
+            list.append(json.dumps(metrics))
+        return list
+
+    def get_metric2_2(self):
+        list = []
+        for i in range(0, 10, 1):
+            metrics = {"name": "foo",
+                       "dimensions": {
+                           "key1": "value1",
+                           "key2": "value2"
+                       },
+                       "timestamp":
+                           tu.iso8601_from_timestamp(
+                               tu.utcnow_ts() + i * 20 - 140),
+                       "value": i * 10 + 200}
+            list.append(json.dumps(metrics))
+        return list
+
+    def get_metric1(self):
+        list = []
+        metrics = {"name": "biz",
+                   "dimensions": {
+                       "hostname": "h1",
+                       "key2": "value2"
+                   },
+                   "timestamp":
+                       tu.iso8601_from_timestamp(tu.utcnow_ts()),
+                   "value": 1300}
+        list.append(json.dumps(metrics))
+        metrics = {"name": "biz",
+                   "dimensions": {
+                       "hostname": "h1",
+                       "key1": "value1",
+                       "key2": "value2",
+                       "key3": "value3"
+                   },
+                   "timestamp":
+                       tu.iso8601_from_timestamp(tu.utcnow_ts()),
+                   "value": 1500}
+        list.append(json.dumps(metrics))
+        metrics = {"name": "biz",
+                   "dimensions": {
+                       "hostname": "h2",
+                       "key2": "value2"
+                   },
+                   "timestamp":
+                       tu.iso8601_from_timestamp(tu.utcnow_ts()),
+                   "value": 1500}
+        list.append(json.dumps(metrics))
+        metrics = {"name": "biz",
+                   "dimensions": {
+                       "hostname": "h3",
+                       "key2": "value2"
+                   },
+                   "timestamp":
+                       tu.iso8601_from_timestamp(tu.utcnow_ts()),
+                   "value": 1200}
+        list.append(json.dumps(metrics))
+        return list
+
+    def get_metric4(self):
+        list = []
+        metrics = {"name": "biz",
+                   "dimensions": {
+                       "hostname": "h1",
+                       "key2": "value2"
+                   },
+                   "timestamp":
+                       tu.iso8601_from_timestamp(tu.utcnow_ts() - 200),
+                   "value": 1300}
+        list.append(json.dumps(metrics))
+        metrics = {"name": "biz",
+                   "dimensions": {
+                       "hostname": "h1",
+                       "key2": "value2",
+                   },
+                   "timestamp":
+                       tu.iso8601_from_timestamp(tu.utcnow_ts() - 30),
+                   "value": 1200}
+        list.append(json.dumps(metrics))
+        metrics = {"name": "biz",
+                   "dimensions": {
+                       "hostname": "h1",
+                       "key1": "value1",
+                       "key2": "value2",
+                       "key3": "value3"
+                   },
+                   "timestamp":
+                       tu.iso8601_from_timestamp(tu.utcnow_ts()),
+                   "value": 1601}
+        list.append(json.dumps(metrics))
+        return list
+
+    def get_metric5(self):
+        list = []
+        metrics = {"name": "biz",
+                   "dimensions": {
+                       "hostname": "h1",
+                       "key2": "value2"
+                   },
+                   "timestamp":
+                       tu.iso8601_from_timestamp(tu.utcnow_ts()),
+                   "value": 2000}
+        list.append(json.dumps(metrics))
+        metrics = {"name": "biz",
+                   "dimensions": {
+                       "hostname": "h1",
+                       "system": "windows",
+                       "key2": "value2"
+                   },
+                   "timestamp":
+                       tu.iso8601_from_timestamp(tu.utcnow_ts()),
+                   "value": 1300}
+        list.append(json.dumps(metrics))
+        metrics = {"name": "biz",
+                   "dimensions": {
+                       "hostname": "h1",
+                       "system": "linux",
+                       "key2": "value2",
+                   },
+                   "timestamp":
+                       tu.iso8601_from_timestamp(tu.utcnow_ts() - 30),
+                   "value": 1200}
+        list.append(json.dumps(metrics))
+        metrics = {"name": "biz",
+                   "dimensions": {
+                       "hostname": "h1",
+                       "system": "windows",
+                       "key1": "value1",
+                       "key2": "value2",
+                       "key3": "value3"
+                   },
+                   "timestamp":
+                       tu.iso8601_from_timestamp(tu.utcnow_ts()),
+                   "value": 1601}
+        list.append(json.dumps(metrics))
+        metrics = {"name": "biz",
+                   "dimensions": {
+                       "hostname": "h2",
+                       "system": "linux",
+                       "key1": "value1",
+                       "key2": "value2",
+                       "key3": "value3"
+                   },
+                   "timestamp":
+                       tu.iso8601_from_timestamp(tu.utcnow_ts()),
+                   "value": 1601}
+        list.append(json.dumps(metrics))
+        return list
+
+    def get_metric0(self):
+        list = []
+        metrics = {"name": "baz",
+                   "dimensions": {
+                       "घोड़ा": "馬",
+                       "dn2": "dv2",
+                       "千幸福的笑脸घ": "千幸福的笑脸घ"
+                   },
+                   "timestamp":
+                       tu.iso8601_from_timestamp(tu.utcnow_ts()),
+                   "value": 1500}
+        list.append(json.dumps(metrics))
+        metrics = {"name": "-_.千幸福的笑脸",
+                   "dimensions": {
+                       "घोड़ा": "馬",
+                       "dn2": "dv2",
+                       "千幸福的笑脸घ": "千幸福的笑脸घ"
+                   },
+                   "timestamp":
+                       tu.iso8601_from_timestamp(tu.utcnow_ts()),
+                   "value": 1500}
+        list.append(json.dumps(metrics))
+        metrics = {"name": "ເຮືອນ",
+                   "dimensions": {
+                       "dn3": "dv3",
+                       "家": "дом"
+                   },
+                   "timestamp":
+                       tu.iso8601_from_timestamp(tu.utcnow_ts()),
+                   "value": 5}
+        list.append(json.dumps(metrics))
+        metrics = {"name": "biz",
+                   "dimensions": {
+                       "dn5": "dv58"
+                   },
+                   "timestamp":
+                       tu.iso8601_from_timestamp(tu.utcnow_ts()),
+                   "value": 5}
+        list.append(json.dumps(metrics))
+        metrics = {"name": "biz",
+                   "dimensions": {
+                       "dn5": "dv58"
+                   },
+                   "timestamp":
+                       tu.iso8601_from_timestamp(tu.utcnow_ts()),
+                   "value": 95}
+        list.append(json.dumps(metrics))
+        return list
+
+    def get_metric_wrong_1(self):
+        list = []
+        metrics = {"name": "biz",
+                   "dimensions": {
+                       "hostname": "h1",
+                       "key2": "value2"
+                   },
+                   "timestamp":
+                       tu.iso8601_from_timestamp(tu.utcnow_ts()),
+                   "value": 1300}
+        list.append(json.dumps(metrics))
+        metrics = {"name": "biz",
+                   "dimensions": {
+                       "hostname": "h1",
+                       "key1": "value1",
+                       "key2": "value2",
+                       "key3": "value3"
+                   },
+                   "timestamp":
+                       tu.iso8601_from_timestamp(tu.utcnow_ts())}
+        list.append(json.dumps(metrics))
+        return list
+
+    def get_metric_not_match(self):
+        list = []
+        metrics = {"name": "biz",
+                   "dimensions": {
+                       "hostname": "h1",
+                       "key2": "value2"
+                   },
+                   "timestamp":
+                       tu.iso8601_from_timestamp(tu.utcnow_ts()),
+                   "value": 1300}
+        list.append(json.dumps(metrics))
+        metrics = {"name": "biz",
+                   "dimensions": {
+                       "hostname": "h1",
+                       "key1": "value1",
+                       "key3": "value3"
+                   },
+                   'value': 15000,
+                   "timestamp":
+                       tu.iso8601_from_timestamp(tu.utcnow_ts())}
+        list.append(json.dumps(metrics))
+        metrics = {"name": "biz",
+                   "dimensions": {
+                       "hostname": "h1",
+                       "key2": "value1",
+                       "key3": "value3"
+                   },
+                   'value': 15000,
+                   "timestamp":
+                       tu.iso8601_from_timestamp(tu.utcnow_ts())}
+        list.append(json.dumps(metrics))
+        metrics = {"name": "biz",
+                   "dimensions": {
+                       "key2": "value1",
+                       "key3": "value3"
+                   },
+                   'value': 15000,
+                   "timestamp":
+                       tu.iso8601_from_timestamp(tu.utcnow_ts())}
+        list.append(json.dumps(metrics))
+        return list
+
+    def setUp(self):
+        super(TestThresholdingProcessor, self).setUp()
+
+    def test__init_(self):
+        """Test processor _init_.
+
+        If alarm definition is not in standard format,
+        the processor cannot be successfully initialized.
+        Alarm_definition3 is a bad one.
+        Processor _init_ will fail on this case.
+        """
+        tp = None
+        try:
+            tp = processor.ThresholdingProcessor(self.alarm_definition0)
+        except Exception:
+            tp = None
+        self.assertIsInstance(tp, processor.ThresholdingProcessor)
+        try:
+            tp = processor.ThresholdingProcessor(self.alarm_definition1)
+        except Exception:
+            tp = None
+        self.assertIsInstance(tp, processor.ThresholdingProcessor)
+        try:
+            tp = processor.ThresholdingProcessor(self.alarm_definition2)
+        except Exception:
+            tp = None
+        self.assertIsInstance(tp, processor.ThresholdingProcessor)
+        try:
+            tp = processor.ThresholdingProcessor(self.alarm_definition3)
+        except Exception:
+            tp = None
+        self.assertIsNone(tp)
+
+    def test_process_alarms(self):
+        """Test if alarm is correctly produced."""
+
+        # test utf8 dimensions and compound logic expr
+        # init processor
+        tp = processor.ThresholdingProcessor(self.alarm_definition0)
+        # send metrics to the processor
+        metrics_list = self.get_metric0()
+        for metrics in metrics_list:
+            tp.process_metrics(metrics)
+        # manually call the function to update alarms
+        alarms = tp.process_alarms()
+        print (alarms)
+        self.assertEqual(1, len(alarms))
+        self.assertEqual('ALARM', json.loads(alarms[0])['state'])
+
+        # test more than 1 periods
+        tp = processor.ThresholdingProcessor(self.alarm_definition0)
+        metrics_list = self.get_metric0()
+        for metrics in metrics_list[0:2]:
+            tp.process_metrics(metrics)
+        alarms = tp.process_alarms()
+        print (alarms)
+        self.assertEqual(0, len(alarms))
+        self.assertEqual('UNDETERMINED', tp.expr_data_queue[None]['state'])
+        tp = processor.ThresholdingProcessor(self.alarm_definition2)
+        metrics_list = self.get_metric2_0()
+        for metrics in metrics_list:
+            tp.process_metrics(metrics)
+        alarms = tp.process_alarms()
+        print (alarms)
+        self.assertEqual(1, len(alarms))
+        self.assertEqual('OK', json.loads(alarms[0])['state'])
+        tp = processor.ThresholdingProcessor(self.alarm_definition2)
+        metrics_list = self.get_metric2_1()
+        for metrics in metrics_list:
+            tp.process_metrics(metrics)
+        alarms = tp.process_alarms()
+        print (alarms)
+        self.assertEqual(1, len(alarms))
+        self.assertEqual('ALARM', json.loads(alarms[0])['state'])
+        print (json.loads(alarms[0])['sub_alarms'][0]['current_values'])
+        tp = processor.ThresholdingProcessor(self.alarm_definition2)
+        metrics_list = self.get_metric2_2()
+        for metrics in metrics_list:
+            tp.process_metrics(metrics)
+        alarms = tp.process_alarms()
+        print (alarms)
+        self.assertEqual(0, len(alarms))
+
+        # test alarms with match_up
+        tp = processor.ThresholdingProcessor(self.alarm_definition1)
+        metrics_list = self.get_metric1()
+        for metrics in metrics_list:
+            tp.process_metrics(metrics)
+        alarms = tp.process_alarms()
+        print (alarms)
+        self.assertEqual(3, len(alarms))
+        self.assertEqual('ALARM', tp.expr_data_queue['h1,']['state'])
+        self.assertEqual('ALARM', tp.expr_data_queue['h2,']['state'])
+        self.assertEqual('OK', tp.expr_data_queue['h3,']['state'])
+
+        # test alarms with multiple match_ups
+        tp = processor.ThresholdingProcessor(self.alarm_definition5)
+        metrics_list = self.get_metric5()
+        for metrics in metrics_list:
+            tp.process_metrics(metrics)
+        alarms = tp.process_alarms()
+        print (alarms)
+        self.assertEqual(3, len(alarms))
+
+        # test alarms with metrics having more dimensions
+        tp = processor.ThresholdingProcessor(self.alarm_definition4)
+        metrics_list = self.get_metric4()
+        for metrics in metrics_list:
+            tp.process_metrics(metrics)
+        alarms = tp.process_alarms()
+        print (alarms)
+        self.assertEqual(1, len(alarms))
+        self.assertEqual(1, len(json.loads(alarms[0])['metrics']))
+        print (json.loads(alarms[0])['sub_alarms'][0]['current_values'])
+        self.assertEqual('ALARM', json.loads(alarms[0])['state'])
+
+        # test when receiving wrong format metrics
+        tp = processor.ThresholdingProcessor(self.alarm_definition1)
+        metrics_list = self.get_metric_wrong_1()
+        for metrics in metrics_list:
+            tp.process_metrics(metrics)
+        alarms = tp.process_alarms()
+        print (alarms)
+        self.assertEqual(1, len(alarms))
+        self.assertEqual([1300],
+                         json.loads(alarms[0])
+                         ['sub_alarms'][0]['current_values'])
+
+        # test when received metrics dimension not match
+        tp = processor.ThresholdingProcessor(self.alarm_definition1)
+        alarms = tp.process_alarms()
+        print (alarms)
+        metrics_list = self.get_metric_not_match()
+        for metrics in metrics_list:
+            tp.process_metrics(metrics)
+        alarms = tp.process_alarms()
+        print (alarms)
+        self.assertEqual('OK', json.loads(alarms[0])['state'])
+
+        # test a success update alarm definition
+        tp = processor.ThresholdingProcessor(self.alarm_definition1)
+        metrics_list = self.get_metric1()
+        for metrics in metrics_list:
+            tp.process_metrics(metrics)
+        alarms = tp.process_alarms()
+        print (alarms)
+        re = tp.update_thresh_processor(self.alarm_definition1_update)
+        self.assertEqual(True, re)
+        alarms = tp.process_alarms()
+        print (alarms)
+        self.assertEqual(3, len(alarms))
+
+        tp = processor.ThresholdingProcessor(self.alarm_definition2)
+        re = tp.update_thresh_processor(self.alarm_definition2_update)
+        self.assertEqual(True, re)
+
+        # test a failed update alarm definition
+        tp = processor.ThresholdingProcessor(self.alarm_definition1)
+        metrics_list = self.get_metric1()
+        for metrics in metrics_list:
+            tp.process_metrics(metrics)
+        alarms = tp.process_alarms()
+        re = tp.update_thresh_processor(self.alarm_definition1_update_wrong1)
+        self.assertEqual(False, re)
+        alarms = tp.process_alarms()
+        self.assertEqual([], alarms)
+        re = tp.update_thresh_processor(self.alarm_definition1_update_wrong2)
+        self.assertEqual(False, re)
+        re = tp.update_thresh_processor(self.alarm_definition1_update_wrong3)
+        self.assertEqual(False, re)


### PR DESCRIPTION
1. in microservice, add an thresh processor:
the thresh processor offers three APIs can be called by thresh engine:
a. process_metrics(). consume new metrics coming, giving to the sub alarm exprs who want them
b. process_alarms(). scan all the metrics stored, to produce alarms
c. update_thresh_processor(). to update alarm definition used in the processor.

2. in common, add a set of calc functions for expr processing

3. in common, modify alarm expr parser to add two functions needed by
processor

4. add unittest for all three files.