### PR TITLE
add calculator and validator for alarm expr; modify alarm expr parser

### DIFF
--- a/monasca/common/alarm_expr_calculator.py
+++ b/monasca/common/alarm_expr_calculator.py
@@ -1,0 +1,87 @@
+# Copyright 2015 Carnegie Mellon University
+# Author: Yihan Wang <wangff9@gmail.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+def calc_value(func, data_list):
+    """Calc float values according to 5 functions."""
+    ops = {'SUM': sum,
+           'AVG': lambda x: sum(x) / len(x),
+           'MAX': max,
+           'MIN': min,
+           'COUNT': len}
+    if len(data_list) == 0 or func not in ops:
+        return None
+    else:
+        return ops[func](data_list)
+
+
+def compare_thresh(values, op, thresh):
+    """Check if value from metrics exceeds thresh.
+
+    Only the value in each period meet thresh, the alarm state can be 'ALARM'.
+
+    For example, the alarm definition defines 3 periods, values = [a,b,c].
+    If the value in any period doesn't meet thresh,
+    then alarm state must be 'OK';
+    If some values are None (means no metrics in that period)
+    but all other values meet thresh,
+    we still don't know if the alarm can be triggered,
+    so it's 'UNDETERMINED';
+    otherwise, the state can be 'ALARM'
+    """
+
+    state = 'OK'
+    for value in values:
+        if value:
+            if op == 'GT' and value <= thresh:
+                return state
+            elif op == 'LT' and value >= thresh:
+                return state
+            elif op == 'LTE' and value > thresh:
+                return state
+            elif op == 'GTE' and value < thresh:
+                return state
+    state = 'ALARM'
+    for value in values:
+        if value is None:
+            state = 'UNDETERMINED'
+    return state
+
+
+def calc_logic(logic_operator, subs):
+    """Calc overall state of an alarm expression.
+
+    'OK' means False;
+    'ALARM' means True;
+    'UNDETERMINED' means either True or False.
+    """
+    if logic_operator == 'AND':
+        state = 'ALARM'
+        for o in subs:
+            if o == 'OK':
+                return 'OK'
+            elif o == 'UNDETERMINED':
+                state = 'UNDETERMINED'
+        return state
+    elif logic_operator == 'OR':
+        state = 'OK'
+        for o in subs:
+            if o == 'ALARM':
+                return 'ALARM'
+            elif o == 'UNDETERMINED':
+                state = 'UNDETERMINED'
+        return state
+    else:
+        return 'UNDETERMINED'

--- a/monasca/common/alarm_expr_validator.py
+++ b/monasca/common/alarm_expr_validator.py
@@ -1,0 +1,77 @@
+# Copyright 2015 Carnegie Mellon University
+# Author: Yihan Wang <wangff9@gmail.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+import json
+from monasca.common import alarm_expr_parser as parser
+
+
+key_set = ['expression',
+           'alarm_actions',
+           'ok_actions',
+           'undetermined_actions',
+           'match_by',
+           'name',
+           'description']
+
+
+def is_valid_alarm_definition(alarm_def_json):
+    alarm_definition = json.loads(alarm_def_json)
+    for key in key_set:
+        if key not in alarm_definition:
+            return False
+    expression = alarm_definition['expression']
+    alarm_parser = parser.AlarmExprParser(expression)
+    if not alarm_parser.parse_result:
+        return False
+    return True
+
+
+def is_valid_update_alarm_definition(ori_alarm_def_json, new_alarm_def_json):
+    # both should be valid alarm definition
+    if (not (is_valid_alarm_definition(ori_alarm_def_json)
+             and is_valid_alarm_definition(new_alarm_def_json))):
+        return False
+    ori_alarm_definition = json.loads(ori_alarm_def_json)
+    new_alarm_definition = json.loads(new_alarm_def_json)
+
+    # match_by should not change
+    if ori_alarm_definition['match_by'] != new_alarm_definition['match_by']:
+        return False
+
+    ori_expression = ori_alarm_definition['expression']
+    ori_alarm_parser = parser.AlarmExprParser(ori_expression)
+    ori_sub_expr_list = ori_alarm_parser.sub_expr_list
+    new_expression = new_alarm_definition['expression']
+    new_alarm_parser = parser.AlarmExprParser(new_expression)
+    new_sub_expr_list = new_alarm_parser.sub_expr_list
+
+    # should have same number of sub alarm exprs
+    l = len(ori_sub_expr_list)
+    if not new_sub_expr_list or l != len(new_sub_expr_list):
+        return False
+
+    for i in range(l):
+        sub_expr_ori = ori_sub_expr_list[i]
+        sub_expr_new = new_sub_expr_list[i]
+        # each metrics in alarm expr should remain the same
+        if (sub_expr_ori.normalized_metric_name
+                != sub_expr_new.normalized_metric_name):
+            return False
+        if (sub_expr_ori.dimensions_as_dict
+                != sub_expr_new.dimensions_as_dict):
+            return False
+
+    return True

--- a/monasca/tests/common/test_alarm_expr_calculator.py
+++ b/monasca/tests/common/test_alarm_expr_calculator.py
@@ -1,0 +1,79 @@
+# Copyright 2015 Carnegie Mellon University
+# Author: Yihan Wang <wangff9@gmail.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from monasca.common import alarm_expr_calculator as calculator
+from monasca.openstack.common import log
+from monasca import tests
+import random
+import time
+
+
+LOG = log.getLogger(__name__)
+
+
+class TestAlarmExprCalculator(tests.BaseTestCase):
+    def setUp(self):
+        super(TestAlarmExprCalculator, self).setUp()
+
+    def test_calc_value(self):
+        self.assertEqual(0, calculator.calc_value('MAX', [0]))
+        data = []
+        self.assertEqual(None, calculator.calc_value('MAX', data))
+        random.seed(time.time())
+        for i in range(0, 30, 1):
+            data.append(random.uniform(0, 1000))
+        self.assertEqual(max(data), calculator.calc_value('MAX', data))
+        self.assertEqual(sum(data), calculator.calc_value('SUM', data))
+        self.assertEqual(len(data), calculator.calc_value('COUNT', data))
+        self.assertEqual(min(data), calculator.calc_value('MIN', data))
+        self.assertEqual(sum(data) / len(data),
+                         calculator.calc_value('AVG', data))
+
+    def test_compare_thresh(self):
+        values = [501, 500, 4999]
+        op = 'GTE'
+        thresh = 500
+        self.assertEqual('ALARM',
+                         calculator.compare_thresh(values, op, thresh))
+        op = 'GT'
+        thresh = 500
+        self.assertEqual('OK', calculator.compare_thresh(values, op, thresh))
+        values = [501, 500, 4999, None]
+        op = 'LTE'
+        thresh = 5000
+        self.assertEqual('UNDETERMINED',
+                         calculator.compare_thresh(values, op, thresh))
+        values = [501, 500, 4999, None]
+        op = 'LT'
+        thresh = 4999
+        self.assertEqual('OK', calculator.compare_thresh(values, op, thresh))
+
+    def test_calc_logic(self):
+        op = 'AND'
+        subs = ['ALARM', 'OK', 'ALARM', 'UNDETERMINED']
+        self.assertEqual('OK', calculator.calc_logic(op, subs))
+        subs = ['ALARM', 'UNDETERMINED', 'ALARM', 'UNDETERMINED']
+        self.assertEqual('UNDETERMINED', calculator.calc_logic(op, subs))
+        subs = ['ALARM', 'ALARM', 'ALARM']
+        self.assertEqual('ALARM', calculator.calc_logic(op, subs))
+        op = 'OR'
+        subs = ['ALARM', 'OK', 'ALARM', 'UNDETERMINED']
+        self.assertEqual('ALARM', calculator.calc_logic(op, subs))
+        subs = ['UNDETERMINED', 'OK', 'UNDETERMINED']
+        self.assertEqual('UNDETERMINED', calculator.calc_logic(op, subs))
+        subs = ['OK', 'OK', 'OK']
+        self.assertEqual('OK', calculator.calc_logic(op, subs))
+        op = 'NOT'
+        self.assertEqual('UNDETERMINED', calculator.calc_logic(op, subs))

--- a/monasca/tests/common/test_alarm_expr_validator.py
+++ b/monasca/tests/common/test_alarm_expr_validator.py
@@ -1,0 +1,244 @@
+# -*- coding: utf-8 -*-
+# Copyright 2015 Carnegie Mellon University
+# Author: Yihan Wang <wangff9@gmail.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import json
+from monasca.common import alarm_expr_validator as validator
+from monasca.openstack.common import log
+from monasca import tests
+
+
+LOG = log.getLogger(__name__)
+
+
+class TestAlarmExprCalculator(tests.BaseTestCase):
+    def __init__(self, *args, **kwargs):
+        super(TestAlarmExprCalculator, self).__init__(*args, **kwargs)
+        self.alarm_definition0 = json.dumps({
+            "id": "f9935bcc-9641-4cbf-8224-0993a947ea83",
+            "name": "Average CPU percent greater than 10",
+            "description":
+                "The average CPU percent is greater than 10",
+            "expression":
+                "max(-_.千幸福的笑脸{घोड़ा=馬,  "
+                "dn2=dv2,"
+                "千幸福的笑脸घ=千幸福的笑脸घ}) gte 100 "
+                "times 1 And "
+                "(min(ເຮືອນ{dn3=dv3,家=дом}) < 10 "
+                "or sum(biz{dn5=dv58}) >9 9and "
+                "count(fizzle) lt 0 or count(baz) > 1)",
+            "match_by": [],
+            "severity": "LOW",
+            "ok_actions": [
+                "c60ec47e-5038-4bf1-9f95-4046c6e9a759"
+            ],
+            "alarm_actions": [
+                "c60ec47e-5038-4bf1-9f95-4046c6e9a759"
+            ],
+            "undetermined_actions": [
+                "c60ec47e-5038-4bf1-9f95-4046c6e9a759"
+            ]})
+        self.alarm_definition0_wrong0 = json.dumps({
+            "id": "f9935bcc-9641-4cbf-8224-0993a947ea83",
+            "name": "Average CPU percent greater than 10",
+            "description":
+                "The average CPU percent is greater than 10",
+            "expression":
+                "max(-_.千幸福的笑脸{घोड़ा=馬,  "
+                "dn2=dv2,"
+                "千幸福的笑脸घ=千幸福的笑脸घ}) gte 100 "
+                "times 1 And "
+                "(min(ເຮືອນ{dn3=dv3,家=дом}) < 10 "
+                "or sum(biz{dn5=dv58}) >9 9and "
+                "count(fizzle) lt 0 or count(baz) > 1)",
+            "match_by": [],
+            "severity": "LOW",
+            "ok_actions": [
+                "c60ec47e-5038-4bf1-9f95-4046c6e9a759"
+            ],
+            "alarm_actions": [
+                "c60ec47e-5038-4bf1-9f95-4046c6e9a759"
+            ]})
+        self.alarm_definition0_wrong1 = json.dumps({
+            "id": "f9935bcc-9641-4cbf-8224-0993a947ea83",
+            "name": "Average CPU percent greater than 10",
+            "description":
+                "The average CPU percent is greater than 10",
+            "expression":
+                "max(-_.千幸福的笑脸{घोड़ा=馬,  "
+                "dn2=dv2,"
+                "千幸福的笑脸घ=千幸福的笑脸घ}) gte 100 "
+                "times 1 And "
+                "(min(ເຮືອນ{dn3=dv3,家=дом}) < 10 "
+                "or sum(biz=5{dn5=dv58}) >9 9and "
+                "count(fizzle) lt 0 or count(baz) > 1)",
+            "match_by": [],
+            "severity": "LOW",
+            "ok_actions": [
+                "c60ec47e-5038-4bf1-9f95-4046c6e9a759"
+            ],
+            "alarm_actions": [
+                "c60ec47e-5038-4bf1-9f95-4046c6e9a759"
+            ],
+            "undetermined_actions": [
+                "c60ec47e-5038-4bf1-9f95-4046c6e9a759"
+            ]})
+        self.alarm_definition1 = json.dumps({
+            "id": "f9935bcc-9641-4cbf-8224-0993a947ea83",
+            "name": "Average CPU percent greater than 10",
+            "description":
+                "The average CPU percent is greater than 10",
+            "expression": "max(biz{key2=value2})>1400",
+            "match_by": [
+                "hostname"
+            ],
+            "severity": "LOW",
+            "ok_actions": [
+                "c60ec47e-5038-4bf1-9f95-4046c6e9a759"
+            ],
+            "alarm_actions": [
+                "c60ec47e-5038-4bf1-9f95-4046c6e9a759"
+            ],
+            "undetermined_actions": [
+                "c60ec47e-5038-4bf1-9f95-4046c6e9a759"
+            ]})
+        self.alarm_definition1_update = json.dumps({
+            "id": "f9935bcc-9641-4cbf-8224-0993a947ea83",
+            "name": "Average CPU percent greater than 10",
+            "description":
+                "The average CPU percent is greater than 10",
+            "expression": "min(biz{key2=value2})<1450",
+            "match_by": [
+                "hostname"
+            ],
+            "severity": "LOW",
+            "ok_actions": [
+                "c60ec47e-5038-4bf1-9f95-4046c6e9a759"
+            ],
+            "alarm_actions": [
+                "c60ec47e-5038-4bf1-9f95-4046c6e9a759"
+            ],
+            "undetermined_actions": [
+                "c60ec47e-5038-4bf1-9f95-4046c6e9a759"
+            ]})
+        self.alarm_definition1_update_wrong0 = json.dumps({
+            "id": "f9935bcc-9641-4cbf-8224-0993a947ea83",
+            "name": "Average CPU percent greater than 10",
+            "description":
+                "The average CPU percent is greater than 10",
+            "expression": "min(biz{key2=value1})<1450",
+            "match_by": [
+                "hostname"
+            ],
+            "severity": "LOW",
+            "ok_actions": [
+                "c60ec47e-5038-4bf1-9f95-4046c6e9a759"
+            ],
+            "alarm_actions": [
+                "c60ec47e-5038-4bf1-9f95-4046c6e9a759"
+            ],
+            "undetermined_actions": [
+                "c60ec47e-5038-4bf1-9f95-4046c6e9a759"
+            ]})
+        self.alarm_definition1_update_wrong1 = json.dumps({
+            "id": "f9935bcc-9641-4cbf-8224-0993a947ea83",
+            "name": "Average CPU percent greater than 10",
+            "description":
+                "The average CPU percent is greater than 10",
+            "expression": "min(biz{key2=value2})<1450",
+            "match_by": [
+                "os"
+            ],
+            "severity": "LOW",
+            "ok_actions": [
+                "c60ec47e-5038-4bf1-9f95-4046c6e9a759"
+            ],
+            "alarm_actions": [
+                "c60ec47e-5038-4bf1-9f95-4046c6e9a759"
+            ],
+            "undetermined_actions": [
+                "c60ec47e-5038-4bf1-9f95-4046c6e9a759"
+            ]})
+        self.alarm_definition1_update_wrong2 = json.dumps({
+            "id": "f9935bcc-9641-4cbf-8224-0993a947ea83",
+            "name": "Average CPU percent greater than 10",
+            "description":
+                "The average CPU percent is greater than 10",
+            "expression": "min(biz{key2=value2})<1450 and max(baz)<500",
+            "match_by": [
+                "hostname"
+            ],
+            "severity": "LOW",
+            "ok_actions": [
+                "c60ec47e-5038-4bf1-9f95-4046c6e9a759"
+            ],
+            "alarm_actions": [
+                "c60ec47e-5038-4bf1-9f95-4046c6e9a759"
+            ],
+            "undetermined_actions": [
+                "c60ec47e-5038-4bf1-9f95-4046c6e9a759"
+            ]})
+        self.alarm_definition1_update_wrong3 = json.dumps({
+            "id": "f9935bcc-9641-4cbf-8224-0993a947ea83",
+            "name": "Average CPU percent greater than 10",
+            "description":
+                "The average CPU percent is greater than 10",
+            "expression": "min(baz{key2=value2})<1450",
+            "match_by": [
+                "hostname"
+            ],
+            "severity": "LOW",
+            "ok_actions": [
+                "c60ec47e-5038-4bf1-9f95-4046c6e9a759"
+            ],
+            "alarm_actions": [
+                "c60ec47e-5038-4bf1-9f95-4046c6e9a759"
+            ],
+            "undetermined_actions": [
+                "c60ec47e-5038-4bf1-9f95-4046c6e9a759"
+            ]})
+
+    def setUp(self):
+        super(TestAlarmExprCalculator, self).setUp()
+
+    def test_is_valid_alarm_definition(self):
+        self.assertEqual(True, validator.is_valid_alarm_definition(
+            self.alarm_definition1))
+        self.assertEqual(True, validator.is_valid_alarm_definition(
+            self.alarm_definition0))
+        self.assertEqual(True, validator.is_valid_alarm_definition(
+            self.alarm_definition1_update))
+        self.assertEqual(True, validator.is_valid_alarm_definition(
+            self.alarm_definition1_update_wrong0))
+        self.assertEqual(False, validator.is_valid_alarm_definition(
+            self.alarm_definition0_wrong0))
+        self.assertEqual(False, validator.is_valid_alarm_definition(
+            self.alarm_definition0_wrong1))
+        self.assertEqual(True, validator.is_valid_alarm_definition(
+            self.alarm_definition1_update_wrong1))
+
+    def test_is_valid_update_alarm_definition(self):
+        self.assertEqual(True, validator.is_valid_update_alarm_definition(
+            self.alarm_definition1, self.alarm_definition1_update))
+        self.assertEqual(False, validator.is_valid_update_alarm_definition(
+            self.alarm_definition1, self.alarm_definition0_wrong0))
+        self.assertEqual(False, validator.is_valid_update_alarm_definition(
+            self.alarm_definition1, self.alarm_definition1_update_wrong0))
+        self.assertEqual(False, validator.is_valid_update_alarm_definition(
+            self.alarm_definition1, self.alarm_definition1_update_wrong1))
+        self.assertEqual(False, validator.is_valid_update_alarm_definition(
+            self.alarm_definition1, self.alarm_definition1_update_wrong2))
+        self.assertEqual(False, validator.is_valid_update_alarm_definition(
+            self.alarm_definition1, self.alarm_definition1_update_wrong3))


### PR DESCRIPTION
this patch goes into monasca.common:
1. alarm_expr_parser, add several functions.
assumption of the parser: in the expr, metrics name and dimension key/value should not contain space(if have space, parser will auto delete them); not case sensitive, max(CPU{A=1})>100 and max(cpu{a=1}) consider the same.

2. alarm_expr_calculator, modified a bit according to last comment

3. alarm_expr_validator. 
New created py. This py offers two functions for alarm definition validation.
Previously, the validation work is inside the thresh_processor. Now I make it common. alarm def API server should use it, so all the alarm definition messages in the Kafka are already validated.

Unittest for all three added.
pep8 py27 passed