### PR TITLE
add thresh processor and unittest

### DIFF
--- a/monasca/microservice/thresholding_processor.py
+++ b/monasca/microservice/thresholding_processor.py
@@ -1,0 +1,289 @@
+# Copyright 2015 Carnegie Mellon University
+# Author: Yihan Wang <wangff9@gmail.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import collections
+import json
+from monasca.common import alarm_expr_calculator as calculator
+from monasca.common import alarm_expr_parser as parser
+from monasca.openstack.common import log
+from monasca.openstack.common import timeutils as tu
+import time
+import uuid
+
+
+LOG = log.getLogger(__name__)
+
+
+class ThresholdingProcessor(object):
+    def __init__(self, alarm_def):
+        """One processor instance hold one alarm definition."""
+        LOG.debug('initializing ThresholdProcessor!')
+        super(ThresholdingProcessor, self).__init__()
+        self.alarm_definition = json.loads(alarm_def)
+        self.expression = self.alarm_definition['expression']
+        self.match_by = self.alarm_definition['match_by']
+        self.expr_data_queue = {}
+        self.related_metrics = {}
+        if len(self.match_by) == 0:
+            self.match_by = None
+        alarm_parser = parser.AlarmExprParser(self.expression)
+        self.parse_result = alarm_parser.parse_result
+        self.sub_expr_list = alarm_parser.sub_expr_list
+        self.related_metrics[None] = alarm_parser.related_metrics
+        self.sub_alarm_expr = alarm_parser.sub_alarm_expressions
+        LOG.debug('successfully initialize ThresholdProcessor!')
+
+    def update_thresh_processor(self, alarm_def):
+        def update_data():
+            # inherit previous stored metrics values
+            for name in self.expr_data_queue:
+                ts = tu.utcnow_ts()
+                new_expr_data_queue[name] = {
+                    'data': {},
+                    'state': 'UNDETERMINED',
+                    'create_timestamp':
+                        self.expr_data_queue[name]['create_timestamp'],
+                    'update_timestamp': ts,
+                    'state_update_timestamp':
+                        self.expr_data_queue[name]['state_update_timestamp']
+                }
+                for i in range(0, len(new_sub_expr_list), 1):
+                    expr_old = self.sub_expr_list[i].fmtd_sub_expr_str
+                    expr_new = new_sub_expr_list[i].fmtd_sub_expr_str
+                    new_expr_data_queue[name]['data'][expr_new] = {
+                        'state': 'UNDETERMINED',
+                        'metrics':
+                            (self.expr_data_queue[name]
+                             ['data'][expr_old]['metrics']),
+                        'values': []}
+
+        LOG.debug('update ThresholdProcessor!')
+        new_alarm_definition = json.loads(alarm_def)
+        new_expression = new_alarm_definition['expression']
+        alarm_parser = parser.AlarmExprParser(new_expression)
+        new_sub_expr_list = alarm_parser.sub_expr_list
+        new_expr_data_queue = {}
+        update_data()
+        self.expr_data_queue = new_expr_data_queue
+        self.sub_expr_list = new_sub_expr_list
+        self.sub_alarm_expr = alarm_parser.sub_alarm_expressions
+        self.parse_result = alarm_parser.parse_result
+        self.alarm_definition = new_alarm_definition
+        self.expression = new_expression
+        self.match_by = self.alarm_definition['match_by']
+        if len(self.match_by) == 0:
+            self.match_by = None
+        LOG.debug('successfully update ThresholdProcessor!')
+        return True
+
+    def process_metrics(self, metrics):
+        """Add new metrics to matched expr."""
+        try:
+            data = json.loads(metrics)
+            self.add_expr_metrics(data)
+        except Exception:
+            LOG.exception('Received a wrong format metrics')
+
+    def process_alarms(self):
+        """Run every minute to produce alarm."""
+        try:
+            alarm_list = []
+            for m in self.expr_data_queue.keys():
+                is_updated = self.update_state(self.expr_data_queue[m])
+                if is_updated:
+                    alarm_list.append(self.build_alarm(m))
+            return alarm_list
+        except Exception:
+            LOG.exception('process metrics error')
+            return []
+
+    def update_state(self, expr_data):
+        """Update the state of each alarm under this alarm definition."""
+
+        def _calc_state(operand):
+            if operand.logic_operator:
+                subs = []
+                for o in operand.sub_expr_list:
+                    subs.append(_calc_state(o))
+                return calculator.calc_logic(operand.logic_operator, subs)
+            else:
+                return expr_data['data'][operand.fmtd_sub_expr_str]['state']
+
+        for sub_expr in self.sub_expr_list:
+            self.update_sub_expr_state(sub_expr, expr_data)
+        state_new = _calc_state(self.parse_result)
+        if state_new != expr_data['state']:
+            expr_data['state_update_timestamp'] = tu.utcnow_ts()
+            expr_data['update_timestamp'] = tu.utcnow_ts()
+            expr_data['state'] = state_new
+            return True
+        else:
+            return False
+
+    def update_sub_expr_state(self, expr, expr_data):
+        def _update_metrics():
+            """Delete metrics not in period."""
+            data_list = expr_data['data'][expr.fmtd_sub_expr_str]['metrics']
+            start_time = t_now - (float(expr.period) + 2) * int(expr.periods)
+            while (len(data_list) != 0
+                   and data_list[0]['timestamp'] < start_time):
+                data_list.popleft()
+
+        def _update_state():
+            """Update state of a sub expr."""
+            data_sub = expr_data['data'][expr.fmtd_sub_expr_str]
+            data_list = data_sub['metrics']
+            if len(data_list) == 0:
+                data_sub['state'] = 'UNDETERMINED'
+            else:
+                period = float(expr.period)
+                periods = int(expr.periods)
+                right = t_now
+                left = right - period
+                temp_data = []
+                value_in_periods = []
+                for i in range(len(data_list) - 1, -1, -1):
+                    if data_list[i]['timestamp'] >= left:
+                        temp_data.append(float(data_list[i]['value']))
+                    else:
+                        value = calculator.calc_value(
+                            expr.normalized_func, temp_data)
+                        value_in_periods.append(value)
+                        right = left
+                        left = right - period
+                        temp_data = []
+                value = calculator.calc_value(
+                    expr.normalized_func, temp_data)
+                value_in_periods.append(value)
+                for i in range(len(value_in_periods), periods, 1):
+                    value_in_periods.append(None)
+                expr_data['data'][expr.fmtd_sub_expr_str]['values'] = (
+                    value_in_periods)
+                expr_data['data'][expr.fmtd_sub_expr_str]['state'] = (
+                    calculator.compare_thresh(
+                        value_in_periods,
+                        expr.normalized_operator,
+                        float(expr.threshold)))
+
+        t_now = tu.iso8601_from_timestamp(tu.utcnow_ts())
+        t_now = tu.parse_isotime(t_now).timetuple()
+        t_now = time.mktime(t_now)
+        _update_metrics()
+        _update_state()
+
+    def add_expr_metrics(self, data):
+        """Add new metrics to matched place."""
+        for sub_expr in self.sub_expr_list:
+            self.add_sub_expr_metrics(sub_expr, data)
+
+    def add_sub_expr_metrics(self, expr, data):
+        """Add new metrics to sub expr place."""
+
+        def _has_match_expr():
+            if (data['name'].lower() != expr.normalized_metric_name):
+                return False
+            metrics_dimensions = {}
+            if 'dimensions' in data:
+                metrics_dimensions = data['dimensions']
+            def_dimensions = expr.dimensions_as_dict
+            for dimension_key in def_dimensions.keys():
+                if dimension_key in metrics_dimensions:
+                    if (metrics_dimensions[dimension_key].lower()
+                            != def_dimensions[dimension_key].lower()):
+                        return False
+                else:
+                    return False
+            return True
+
+        def _add_metrics():
+            temp = None
+            if self.match_by:
+                q_name = self.get_matched_data_queue_name(data)
+                if q_name:
+                    temp = self.expr_data_queue[q_name]
+            else:
+                if None not in self.expr_data_queue:
+                    self.create_data_item(None)
+                temp = self.expr_data_queue[None]
+            if temp:
+                data_list = temp['data'][expr.fmtd_sub_expr_str]
+                data_list['metrics'].append(
+                    {'value': float(data['value']),
+                     'timestamp':
+                         time.mktime(tu.parse_isotime(
+                             data['timestamp']).timetuple())})
+
+        if _has_match_expr():
+            _add_metrics()
+
+    def create_data_item(self, name):
+        """If not exist in dict, create one item."""
+        ts = tu.utcnow_ts()
+        self.expr_data_queue[name] = {
+            'data': {},
+            'state': 'UNDETERMINED',
+            'create_timestamp': ts,
+            'update_timestamp': ts,
+            'state_update_timestamp': ts}
+        for expr in self.sub_expr_list:
+            self.expr_data_queue[name]['data'][expr.fmtd_sub_expr_str] = {
+                'state': 'UNDETERMINED',
+                'metrics': collections.deque(),
+                'values': []}
+
+    def get_matched_data_queue_name(self, data):
+        name = ''
+        for m in self.match_by:
+            if m in data['dimensions']:
+                name = name + data['dimensions'][m] + ','
+            else:
+                return None
+        if name in self.expr_data_queue:
+            return name
+        else:
+            self.related_metrics[name] = []
+            for m in self.related_metrics[None]:
+                temp = m.copy()
+                for match in self.match_by:
+                    temp['dimensions'][match] = data['dimensions'][match]
+                self.related_metrics[name].append(temp)
+            self.create_data_item(name)
+            return name
+
+    def build_alarm(self, name):
+        """Build alarm json."""
+        alarm = {}
+        id = str(uuid.uuid4())
+        alarm['id'] = id
+        alarm['alarm-definition'] = self.alarm_definition
+        alarm['metrics'] = self.related_metrics[name]
+        alarm['state'] = self.expr_data_queue[name]['state']
+        sub_alarms = []
+        dt = self.expr_data_queue[name]['data']
+        for expr in self.sub_expr_list:
+            sub_alarms.append({
+                'sub_alarm_expression':
+                    self.sub_alarm_expr[expr.fmtd_sub_expr_str],
+                'sub_alarm_state': dt[expr.fmtd_sub_expr_str]['state'],
+                'current_values': dt[expr.fmtd_sub_expr_str]['values']
+            })
+        alarm['sub_alarms'] = sub_alarms
+        ct = self.expr_data_queue[name]['create_timestamp']
+        st = self.expr_data_queue[name]['state_update_timestamp']
+        t = self.expr_data_queue[name]['update_timestamp']
+        alarm['state_updated_timestamp'] = tu.iso8601_from_timestamp(st)
+        alarm['updated_timestamp'] = tu.iso8601_from_timestamp(t)
+        alarm['created_timestamp'] = tu.iso8601_from_timestamp(ct)
+        return json.dumps(alarm)

--- a/monasca/tests/microservice/test_thresholding_processor.py
+++ b/monasca/tests/microservice/test_thresholding_processor.py
@@ -1,0 +1,629 @@
+# -*- coding: utf-8 -*-
+# Copyright 2015 Carnegie Mellon University
+# Author: Yihan Wang <wangff9@gmail.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import json
+from monasca.microservice import thresholding_processor as processor
+from monasca.openstack.common import log
+from monasca.openstack.common import timeutils as tu
+from monasca import tests
+
+LOG = log.getLogger(__name__)
+
+
+class TestThresholdingProcessor(tests.BaseTestCase):
+    def __init__(self, *args, **kwargs):
+        super(TestThresholdingProcessor, self).__init__(*args, **kwargs)
+        self.alarm_definition0 = json.dumps({
+            "id": "f9935bcc-9641-4cbf-8224-0993a947ea83",
+            "name": "Average CPU percent greater than 10",
+            "description":
+                "The average CPU percent is greater than 10",
+            "expression":
+                "max(-_.千幸福的笑脸{घोड़ा=馬,  "
+                "dn2=dv2,"
+                "千幸福的笑脸घ=千幸福的笑脸घ}) gte 100 "
+                "times 1 And "
+                "(min(ເຮືອນ{dn3=dv3,家=дом}) < 10 "
+                "or sum(biz{dn5=dv58}) >9 9and "
+                "count(fizzle) lt 0 or count(baz) > 1)",
+            "match_by": [],
+            "severity": "LOW",
+            "ok_actions": [
+                "c60ec47e-5038-4bf1-9f95-4046c6e9a759"
+            ],
+            "alarm_actions": [
+                "c60ec47e-5038-4bf1-9f95-4046c6e9a759"
+            ],
+            "undetermined_actions": [
+                "c60ec47e-5038-4bf1-9f95-4046c6e9a759"
+            ]})
+        self.alarm_definition1 = json.dumps({
+            "id": "f9935bcc-9641-4cbf-8224-0993a947ea83",
+            "name": "Average CPU percent greater than 10",
+            "description":
+                "The average CPU percent is greater than 10",
+            "expression": "max(biz{key2=value2})>1400",
+            "match_by": [
+                "hostname"
+            ],
+            "severity": "LOW",
+            "ok_actions": [
+                "c60ec47e-5038-4bf1-9f95-4046c6e9a759"
+            ],
+            "alarm_actions": [
+                "c60ec47e-5038-4bf1-9f95-4046c6e9a759"
+            ],
+            "undetermined_actions": [
+                "c60ec47e-5038-4bf1-9f95-4046c6e9a759"
+            ]})
+        self.alarm_definition1_update = json.dumps({
+            "id": "f9935bcc-9641-4cbf-8224-0993a947ea83",
+            "name": "Average CPU percent greater than 10",
+            "description":
+                "The average CPU percent is greater than 10",
+            "expression": "min(biz{key2=value2})<1450",
+            "match_by": [
+                "hostname"
+            ],
+            "severity": "LOW",
+            "ok_actions": [
+                "c60ec47e-5038-4bf1-9f95-4046c6e9a759"
+            ],
+            "alarm_actions": [
+                "c60ec47e-5038-4bf1-9f95-4046c6e9a759"
+            ],
+            "undetermined_actions": [
+                "c60ec47e-5038-4bf1-9f95-4046c6e9a759"
+            ]})
+        self.alarm_definition4 = json.dumps({
+            "id": "f9935bcc-9641-4cbf-8224-0993a947ea83",
+            "name": "Average CPU percent greater than 10",
+            "description":
+                "The average CPU percent is greater than 10",
+            "expression": "avg(biz{key2=value2})>1400",
+            "match_by": [
+                "hostname"
+            ],
+            "severity": "LOW",
+            "ok_actions": [
+                "c60ec47e-5038-4bf1-9f95-4046c6e9a759"
+            ],
+            "alarm_actions": [
+                "c60ec47e-5038-4bf1-9f95-4046c6e9a759"
+            ],
+            "undetermined_actions": [
+                "c60ec47e-5038-4bf1-9f95-4046c6e9a759"
+            ]})
+        self.alarm_definition2 = json.dumps({
+            "id": "f9935bcc-9641-4cbf-8224-0993a947ea83",
+            "name": "Average CPU percent greater than 10",
+            "description":
+                "The average CPU percent is greater than 10",
+            "expression": "max(foo)>=100 times 4",
+            "match_by": [],
+            "severity": "LOW",
+            "ok_actions": [
+                "c60ec47e-5038-4bf1-9f95-4046c6e9a759"
+            ],
+            "alarm_actions": [
+                "c60ec47e-5038-4bf1-9f95-4046c6e9a759"
+            ],
+            "undetermined_actions": [
+                "c60ec47e-5038-4bf1-9f95-4046c6e9a759"
+            ]})
+        self.alarm_definition2_update = json.dumps({
+            "id": "f9935bcc-9641-4cbf-8224-0993a947ea83",
+            "name": "Average CPU percent greater than 10",
+            "description":
+                "The average CPU percent is greater than 10",
+            "expression": "max(foo,80)>=100 times 6",
+            "match_by": [],
+            "severity": "LOW",
+            "ok_actions": [
+                "c60ec47e-5038-4bf1-9f95-4046c6e9a759"
+            ],
+            "alarm_actions": [
+                "c60ec47e-5038-4bf1-9f95-4046c6e9a759"
+            ],
+            "undetermined_actions": [
+                "c60ec47e-5038-4bf1-9f95-4046c6e9a759"
+            ]})
+        self.alarm_definition3 = json.dumps({
+            "id": "f9935bcc-9641-4cbf-8224-0993a947ea83",
+            "name": "Average CPU percent greater than 10",
+            "description":
+                "The average CPU percent is greater than 10",
+            "expression": "max(foo{hostname=mini-mon"
+                          ",千=千}, 120)"
+                          " = 100 and (max(bar)>100 "
+                          " or max(biz)>100)",
+            "match_by": [],
+            "severity": "LOW",
+            "ok_actions": [
+                "c60ec47e-5038-4bf1-9f95-4046c6e9a759"
+            ],
+            "alarm_actions": [
+                "c60ec47e-5038-4bf1-9f95-4046c6e9a759"
+            ],
+            "undetermined_actions": [
+                "c60ec47e-5038-4bf1-9f95-4046c6e9a759"
+            ]})
+        self.alarm_definition5 = json.dumps({
+            "id": "f9935bcc-9641-4cbf-8224-0993a947ea83",
+            "name": "Average CPU percent greater than 10",
+            "description":
+                "The average CPU percent is greater than 10",
+            "expression": "avg(biz{key2=value2})>1400",
+            "match_by": [
+                "hostname",
+                "system"
+            ],
+            "severity": "LOW",
+            "ok_actions": [
+                "c60ec47e-5038-4bf1-9f95-4046c6e9a759"
+            ],
+            "alarm_actions": [
+                "c60ec47e-5038-4bf1-9f95-4046c6e9a759"
+            ],
+            "undetermined_actions": [
+                "c60ec47e-5038-4bf1-9f95-4046c6e9a759"
+            ]})
+
+    def get_metric2_0(self):
+        list = []
+        for i in range(0, 10, 1):
+            metrics = {"name": "foo",
+                       "dimensions": {
+                           "key1": "value1",
+                           "key2": "value2"
+                       },
+                       "timestamp":
+                           tu.iso8601_from_timestamp(
+                               tu.utcnow_ts() + i * 20 - 140),
+                       "value": i * 10}
+            list.append(json.dumps(metrics))
+        return list
+
+    def get_metric2_1(self):
+        list = []
+        for i in range(10, 30, 1):
+            metrics = {"name": "foo",
+                       "dimensions": {
+                           "key1": "value1",
+                           "key2": "value2"
+                       },
+                       "timestamp":
+                           tu.iso8601_from_timestamp(
+                               tu.utcnow_ts() + i * 20 - 570),
+                       "value": i * 75}
+            list.append(json.dumps(metrics))
+        return list
+
+    def get_metric2_2(self):
+        list = []
+        for i in range(0, 10, 1):
+            metrics = {"name": "foo",
+                       "dimensions": {
+                           "key1": "value1",
+                           "key2": "value2"
+                       },
+                       "timestamp":
+                           tu.iso8601_from_timestamp(
+                               tu.utcnow_ts() + i * 20 - 140),
+                       "value": i * 10 + 200}
+            list.append(json.dumps(metrics))
+        return list
+
+    def get_metric1(self):
+        list = []
+        metrics = {"name": "biz",
+                   "dimensions": {
+                       "hostname": "h1",
+                       "key2": "value2"
+                   },
+                   "timestamp":
+                       tu.iso8601_from_timestamp(tu.utcnow_ts()),
+                   "value": 1300}
+        list.append(json.dumps(metrics))
+        metrics = {"name": "biz",
+                   "dimensions": {
+                       "hostname": "h1",
+                       "key1": "value1",
+                       "key2": "value2",
+                       "key3": "value3"
+                   },
+                   "timestamp":
+                       tu.iso8601_from_timestamp(tu.utcnow_ts()),
+                   "value": 1500}
+        list.append(json.dumps(metrics))
+        metrics = {"name": "biz",
+                   "dimensions": {
+                       "hostname": "h2",
+                       "key2": "value2"
+                   },
+                   "timestamp":
+                       tu.iso8601_from_timestamp(tu.utcnow_ts()),
+                   "value": 1500}
+        list.append(json.dumps(metrics))
+        metrics = {"name": "biz",
+                   "dimensions": {
+                       "hostname": "h3",
+                       "key2": "value2"
+                   },
+                   "timestamp":
+                       tu.iso8601_from_timestamp(tu.utcnow_ts()),
+                   "value": 1200}
+        list.append(json.dumps(metrics))
+        return list
+
+    def get_metric4(self):
+        list = []
+        metrics = {"name": "biz",
+                   "dimensions": {
+                       "hostname": "h1",
+                       "key2": "value2"
+                   },
+                   "timestamp":
+                       tu.iso8601_from_timestamp(tu.utcnow_ts() - 200),
+                   "value": 1300}
+        list.append(json.dumps(metrics))
+        metrics = {"name": "biz",
+                   "dimensions": {
+                       "hostname": "h1",
+                       "key2": "value2",
+                   },
+                   "timestamp":
+                       tu.iso8601_from_timestamp(tu.utcnow_ts() - 30),
+                   "value": 1200}
+        list.append(json.dumps(metrics))
+        metrics = {"name": "biz",
+                   "dimensions": {
+                       "hostname": "h1",
+                       "key1": "value1",
+                       "key2": "value2",
+                       "key3": "value3"
+                   },
+                   "timestamp":
+                       tu.iso8601_from_timestamp(tu.utcnow_ts()),
+                   "value": 1601}
+        list.append(json.dumps(metrics))
+        return list
+
+    def get_metric5(self):
+        list = []
+        metrics = {"name": "biz",
+                   "dimensions": {
+                       "hostname": "h1",
+                       "key2": "value2"
+                   },
+                   "timestamp":
+                       tu.iso8601_from_timestamp(tu.utcnow_ts()),
+                   "value": 2000}
+        list.append(json.dumps(metrics))
+        metrics = {"name": "biz",
+                   "dimensions": {
+                       "hostname": "h1",
+                       "system": "windows",
+                       "key2": "value2"
+                   },
+                   "timestamp":
+                       tu.iso8601_from_timestamp(tu.utcnow_ts()),
+                   "value": 1300}
+        list.append(json.dumps(metrics))
+        metrics = {"name": "biz",
+                   "dimensions": {
+                       "hostname": "h1",
+                       "system": "linux",
+                       "key2": "value2",
+                   },
+                   "timestamp":
+                       tu.iso8601_from_timestamp(tu.utcnow_ts() - 30),
+                   "value": 1200}
+        list.append(json.dumps(metrics))
+        metrics = {"name": "biz",
+                   "dimensions": {
+                       "hostname": "h1",
+                       "system": "windows",
+                       "key1": "value1",
+                       "key2": "value2",
+                       "key3": "value3"
+                   },
+                   "timestamp":
+                       tu.iso8601_from_timestamp(tu.utcnow_ts()),
+                   "value": 1601}
+        list.append(json.dumps(metrics))
+        metrics = {"name": "biz",
+                   "dimensions": {
+                       "hostname": "h2",
+                       "system": "linux",
+                       "key1": "value1",
+                       "key2": "value2",
+                       "key3": "value3"
+                   },
+                   "timestamp":
+                       tu.iso8601_from_timestamp(tu.utcnow_ts()),
+                   "value": 1601}
+        list.append(json.dumps(metrics))
+        return list
+
+    def get_metric0(self):
+        list = []
+        metrics = {"name": "baz",
+                   "dimensions": {
+                       "घोड़ा": "馬",
+                       "dn2": "dv2",
+                       "千幸福的笑脸घ": "千幸福的笑脸घ"
+                   },
+                   "timestamp":
+                       tu.iso8601_from_timestamp(tu.utcnow_ts()),
+                   "value": 1500}
+        list.append(json.dumps(metrics))
+        metrics = {"name": "-_.千幸福的笑脸",
+                   "dimensions": {
+                       "घोड़ा": "馬",
+                       "dn2": "dv2",
+                       "千幸福的笑脸घ": "千幸福的笑脸घ"
+                   },
+                   "timestamp":
+                       tu.iso8601_from_timestamp(tu.utcnow_ts()),
+                   "value": 1500}
+        list.append(json.dumps(metrics))
+        metrics = {"name": "ເຮືອນ",
+                   "dimensions": {
+                       "dn3": "dv3",
+                       "家": "дом"
+                   },
+                   "timestamp":
+                       tu.iso8601_from_timestamp(tu.utcnow_ts()),
+                   "value": 5}
+        list.append(json.dumps(metrics))
+        metrics = {"name": "biz",
+                   "dimensions": {
+                       "dn5": "dv58"
+                   },
+                   "timestamp":
+                       tu.iso8601_from_timestamp(tu.utcnow_ts()),
+                   "value": 5}
+        list.append(json.dumps(metrics))
+        metrics = {"name": "biz",
+                   "dimensions": {
+                       "dn5": "dv58"
+                   },
+                   "timestamp":
+                       tu.iso8601_from_timestamp(tu.utcnow_ts()),
+                   "value": 95}
+        list.append(json.dumps(metrics))
+        return list
+
+    def get_metric_wrong_1(self):
+        list = []
+        metrics = {"name": "biz",
+                   "dimensions": {
+                       "hostname": "h1",
+                       "key2": "value2"
+                   },
+                   "timestamp":
+                       tu.iso8601_from_timestamp(tu.utcnow_ts()),
+                   "value": 1300}
+        list.append(json.dumps(metrics))
+        metrics = {"name": "biz",
+                   "dimensions": {
+                       "hostname": "h1",
+                       "key1": "value1",
+                       "key2": "value2",
+                       "key3": "value3"
+                   },
+                   "timestamp":
+                       tu.iso8601_from_timestamp(tu.utcnow_ts())}
+        list.append(json.dumps(metrics))
+        return list
+
+    def get_metric_not_match(self):
+        list = []
+        metrics = {"name": "biz",
+                   "dimensions": {
+                       "hostname": "h1",
+                       "key2": "value2"
+                   },
+                   "timestamp":
+                       tu.iso8601_from_timestamp(tu.utcnow_ts()),
+                   "value": 1300}
+        list.append(json.dumps(metrics))
+        metrics = {"name": "biz",
+                   "dimensions": {
+                       "hostname": "h1",
+                       "key1": "value1",
+                       "key3": "value3"
+                   },
+                   'value': 15000,
+                   "timestamp":
+                       tu.iso8601_from_timestamp(tu.utcnow_ts())}
+        list.append(json.dumps(metrics))
+        metrics = {"name": "biz",
+                   "dimensions": {
+                       "hostname": "h1",
+                       "key2": "value1",
+                       "key3": "value3"
+                   },
+                   'value': 15000,
+                   "timestamp":
+                       tu.iso8601_from_timestamp(tu.utcnow_ts())}
+        list.append(json.dumps(metrics))
+        metrics = {"name": "biz",
+                   "dimensions": {
+                       "key2": "value1",
+                       "key3": "value3"
+                   },
+                   'value': 15000,
+                   "timestamp":
+                       tu.iso8601_from_timestamp(tu.utcnow_ts())}
+        list.append(json.dumps(metrics))
+        return list
+
+    def setUp(self):
+        super(TestThresholdingProcessor, self).setUp()
+
+    def test__init_(self):
+        """Test processor _init_.
+
+        If alarm definition is not in standard format,
+        the processor cannot be successfully initialized.
+        Alarm_definition3 is a bad one.
+        Processor _init_ will fail on this case.
+        """
+        tp = None
+        try:
+            tp = processor.ThresholdingProcessor(self.alarm_definition0)
+        except Exception:
+            tp = None
+        self.assertIsInstance(tp, processor.ThresholdingProcessor)
+        try:
+            tp = processor.ThresholdingProcessor(self.alarm_definition1)
+        except Exception:
+            tp = None
+        self.assertIsInstance(tp, processor.ThresholdingProcessor)
+        try:
+            tp = processor.ThresholdingProcessor(self.alarm_definition2)
+        except Exception:
+            tp = None
+        self.assertIsInstance(tp, processor.ThresholdingProcessor)
+        try:
+            tp = processor.ThresholdingProcessor(self.alarm_definition3)
+        except Exception:
+            tp = None
+        self.assertIsNone(tp)
+
+    def test_process_alarms(self):
+        """Test if alarm is correctly produced."""
+
+        # test utf8 dimensions and compound logic expr
+        # init processor
+        tp = processor.ThresholdingProcessor(self.alarm_definition0)
+        # send metrics to the processor
+        metrics_list = self.get_metric0()
+        for metrics in metrics_list:
+            tp.process_metrics(metrics)
+        # manually call the function to update alarms
+        alarms = tp.process_alarms()
+        print (alarms)
+        self.assertEqual(1, len(alarms))
+        self.assertEqual('ALARM', json.loads(alarms[0])['state'])
+
+        # test more than 1 periods
+        tp = processor.ThresholdingProcessor(self.alarm_definition0)
+        metrics_list = self.get_metric0()
+        for metrics in metrics_list[0:2]:
+            tp.process_metrics(metrics)
+        alarms = tp.process_alarms()
+        print (alarms)
+        self.assertEqual(0, len(alarms))
+        self.assertEqual('UNDETERMINED', tp.expr_data_queue[None]['state'])
+        tp = processor.ThresholdingProcessor(self.alarm_definition2)
+        metrics_list = self.get_metric2_0()
+        for metrics in metrics_list:
+            tp.process_metrics(metrics)
+        alarms = tp.process_alarms()
+        print (alarms)
+        self.assertEqual(1, len(alarms))
+        self.assertEqual('OK', json.loads(alarms[0])['state'])
+        tp = processor.ThresholdingProcessor(self.alarm_definition2)
+        metrics_list = self.get_metric2_1()
+        for metrics in metrics_list:
+            tp.process_metrics(metrics)
+        alarms = tp.process_alarms()
+        print (alarms)
+        self.assertEqual(1, len(alarms))
+        self.assertEqual('ALARM', json.loads(alarms[0])['state'])
+        print (json.loads(alarms[0])['sub_alarms'][0]['current_values'])
+        tp = processor.ThresholdingProcessor(self.alarm_definition2)
+        metrics_list = self.get_metric2_2()
+        for metrics in metrics_list:
+            tp.process_metrics(metrics)
+        alarms = tp.process_alarms()
+        print (alarms)
+        self.assertEqual(0, len(alarms))
+
+        # test alarms with match_up
+        tp = processor.ThresholdingProcessor(self.alarm_definition1)
+        metrics_list = self.get_metric1()
+        for metrics in metrics_list:
+            tp.process_metrics(metrics)
+        alarms = tp.process_alarms()
+        print (alarms)
+        self.assertEqual(3, len(alarms))
+        self.assertEqual('ALARM', tp.expr_data_queue['h1,']['state'])
+        self.assertEqual('ALARM', tp.expr_data_queue['h2,']['state'])
+        self.assertEqual('OK', tp.expr_data_queue['h3,']['state'])
+
+        # test alarms with multiple match_ups
+        tp = processor.ThresholdingProcessor(self.alarm_definition5)
+        metrics_list = self.get_metric5()
+        for metrics in metrics_list:
+            tp.process_metrics(metrics)
+        alarms = tp.process_alarms()
+        print (alarms)
+        self.assertEqual(3, len(alarms))
+
+        # test alarms with metrics having more dimensions
+        tp = processor.ThresholdingProcessor(self.alarm_definition4)
+        metrics_list = self.get_metric4()
+        for metrics in metrics_list:
+            tp.process_metrics(metrics)
+        alarms = tp.process_alarms()
+        print (alarms)
+        self.assertEqual(1, len(alarms))
+        self.assertEqual(1, len(json.loads(alarms[0])['metrics']))
+        print (json.loads(alarms[0])['sub_alarms'][0]['current_values'])
+        self.assertEqual('ALARM', json.loads(alarms[0])['state'])
+
+        # test when receiving wrong format metrics
+        tp = processor.ThresholdingProcessor(self.alarm_definition1)
+        metrics_list = self.get_metric_wrong_1()
+        for metrics in metrics_list:
+            tp.process_metrics(metrics)
+        alarms = tp.process_alarms()
+        print (alarms)
+        self.assertEqual(1, len(alarms))
+        self.assertEqual([1300],
+                         json.loads(alarms[0])
+                         ['sub_alarms'][0]['current_values'])
+
+        # test when received metrics dimension not match
+        tp = processor.ThresholdingProcessor(self.alarm_definition1)
+        alarms = tp.process_alarms()
+        print (alarms)
+        metrics_list = self.get_metric_not_match()
+        for metrics in metrics_list:
+            tp.process_metrics(metrics)
+        alarms = tp.process_alarms()
+        print (alarms)
+        self.assertEqual('OK', json.loads(alarms[0])['state'])
+
+        # test a success update alarm definition
+        tp = processor.ThresholdingProcessor(self.alarm_definition1)
+        metrics_list = self.get_metric1()
+        for metrics in metrics_list:
+            tp.process_metrics(metrics)
+        alarms = tp.process_alarms()
+        print (alarms)
+        re = tp.update_thresh_processor(self.alarm_definition1_update)
+        self.assertEqual(True, re)
+        alarms = tp.process_alarms()
+        print (alarms)
+        self.assertEqual(3, len(alarms))
+        tp = processor.ThresholdingProcessor(self.alarm_definition2)
+        re = tp.update_thresh_processor(self.alarm_definition2_update)
+        self.assertEqual(True, re)


### PR DESCRIPTION
ignore pull request #10  and #11 

in this patch:
only thresh processor and the unittest code.

changes:
Now no validation for alarm definition in the processor. 

py27 pep8 passed
-------------------------
To run tox, need 3 pys in monasca.common



