### PR TITLE
Alarms API v1.1

### DIFF
--- a/monasca/tests/v2/elasticsearch/test_alarmdefinitions.py
+++ b/monasca/tests/v2/elasticsearch/test_alarmdefinitions.py
@@ -16,6 +16,7 @@
 
 import falcon
 import mock
+import os
 from oslo.config import fixture as fixture_config
 from oslotest import base
 import requests
@@ -27,45 +28,6 @@ try:
     import ujson as json
 except ImportError:
     import json
-
-
-response_str = """
-            {
-                "hits":{
-                    "hits":[
-                        {
-                            "_score":1.0,
-                            "_type":"alarmdefinitions",
-                            "_id":"72df5ccb-ec6a-4bb4-a15c-939467ccdde0",
-                            "_source":{
-                                "id":"72df5ccb-ec6a-4bb4-a15c-939467ccdde0",
-                                "name":"CPU usage test",
-                                "alarm_actions":
-                                "c60ec47e-5038-4bf1-9f95-4046c6e9a719",
-                                "undetermined_actions":
-                                "c60ec47e-5038-4bf1-9t95-4046c6e9a759",
-                                "ok_actions":
-                                "c60ec47e-5038-4bf1-9f95-4046cte9a759",
-                                "match_by":"hostname",
-                                "severity":"LOW",
-                                "expression":
-                                "max(cpu.usage{os=linux},600)>15",
-                                "description": "Max CPU 15"
-                            },
-                            "_index":"data_20150601000000"
-                        }
-                    ],
-                    "total":1,
-                    "max_score":1.0
-                },
-                "_shards":{
-                    "successful":5,
-                    "failed":0,
-                    "total":5
-                },
-                "took":2,
-            }
-        """
 
 
 class TestAlarmDefinitionUtil(base.BaseTestCase):
@@ -82,32 +44,12 @@ class TestAlarmDefinitionDispatcher(base.BaseTestCase):
         self.CONF.set_override('doc_type', 'fake', group='alarmdefinitions')
         self.CONF.set_override('uri', 'fake_es_uri', group='es_conn')
         super(TestAlarmDefinitionDispatcher, self).setUp()
-        res = mock.Mock()
-        res.status_code = 200
-        res.json.return_value = {
-            "id": "72df5ccb-ec6a-4bb4-a15c-939467ccdde0",
-            "links": [
-                {
-                    "rel": "self",
-                    "href": "http://127.0.0.1:9090/v2.0/alarm-definitions/"
-                            "72df5ccb-ec6a-4bb4-a15c-939467ccdde0"
-                }
-            ],
-            "name": "CPU usage test",
-            "alarm_actions": "c60ec47e-5038-4bf1-9f95-4046c6e9a719",
-            "undetermined_actions": "c60ec47e-5038-4bf1-9t95-4046c6e9a759",
-            "ok_actions": "c60ec47e-5038-4bf1-9f95-4046cte9a759",
-            "match_by": "hostname",
-            "severity": "LOW",
-            "expression": "max(cpu.usage{os=linux},600)>15",
-            "description": "Max CPU 15"
-        }
-        with mock.patch.object(requests, 'get',
-                               return_value=res):
-            self.dispatcher_get = (
-                alarmdefinitions.AlarmDefinitionDispatcher({}))
 
-        res.json.return_value = {}
+        self.dispatcher_get = (
+            alarmdefinitions.AlarmDefinitionDispatcher({}))
+
+        self.dispatcher_get_by_id = (
+            alarmdefinitions.AlarmDefinitionDispatcher({}))
 
         self.dispatcher_post = (
             alarmdefinitions.AlarmDefinitionDispatcher({}))
@@ -118,6 +60,12 @@ class TestAlarmDefinitionDispatcher(base.BaseTestCase):
         self.dispatcher_delete = (
             alarmdefinitions.AlarmDefinitionDispatcher({}))
 
+        dir_path = os.path.dirname(os.path.realpath(__file__))
+        alarms_data_json = open(os.path.join(dir_path,
+                                             'test_alarmdefinitions_data')
+                                ).read().replace('\n', '')
+        self.data = json.loads(alarms_data_json)
+
     def test_initialization(self):
         # test that the doc type of the es connection is fake
         self.assertEqual(self.dispatcher_get._es_conn.doc_type, 'fake')
@@ -127,14 +75,67 @@ class TestAlarmDefinitionDispatcher(base.BaseTestCase):
     def test_do_get_alarm_definitions(self):
         res = mock.Mock()
         req = mock.Mock()
+        req_result = mock.Mock()
+        response_str = self.data
+        req_result.json.return_value = response_str
+        req_result.status_code = 200
+
+        req.query_string = 'name=CPU usage test&dimensions=os:linux'
+        with mock.patch.object(es_conn.ESConnection, 'get_messages',
+                               return_value=req_result):
+            self.dispatcher_get.do_get_alarm_definitions(req, res)
+
+        # test that the response code is 200
+        self.assertEqual(res.status, getattr(falcon, 'HTTP_200'))
+        obj = json.loads(res.body)
+
+        # test that the first response object has the required properties
+        self.assertEqual(obj[0]['id'],
+                         '8c85be40-bfcb-465c-b450-4eea670806a6')
+        self.assertEqual(obj[0]['name'], "CPU usage test")
+        self.assertEqual(obj[0]['alarm_actions'],
+                         "c60ec47e-5038-4bf1-9f95-4046c6e9a719")
+        self.assertEqual(obj[0]['undetermined_actions'],
+                         "c60ec47e-5038-4bf1-9t95-4046c6e9a759")
+        self.assertEqual(obj[0]['ok_actions'],
+                         "c60ec47e-5038-4bf1-9f95-4046cte9a759")
+        self.assertEqual(obj[0]['match_by'], "hostname")
+        self.assertEqual(obj[0]['severity'], "LOW")
+        self.assertEqual(obj[0]['expression'],
+                         "max(cpu.usage{os=linux},600)>15")
+        self.assertNotEqual(obj[0]['expression_data'], None)
+        self.assertEqual(obj[0]['description'], "Max CPU 15")
+
+        # test that the second response object has the required properties
+        self.assertEqual(obj[1]['id'],
+                         'eb43fe12-b442-40b6-aab6-f34450cf90dd')
+        self.assertEqual(obj[1]['name'], "CPU usage in last 4 minutes")
+        self.assertEqual(obj[1]['alarm_actions'],
+                         "c60ec47e-5038-4bf1-9f95-4046c6e9a719")
+        self.assertEqual(obj[1]['undetermined_actions'],
+                         "c60ec47e-5038-4bf1-9t95-4046c6e9a759")
+        self.assertEqual(obj[1]['ok_actions'],
+                         "c60ec47e-5038-4bf1-9f95-4046cte9a759")
+        self.assertEqual(obj[1]['match_by'], "hostname")
+        self.assertEqual(obj[1]['severity'], "LOW")
+        self.assertEqual(obj[1]['expression'],
+                         "max(cpu.usage,60)>10 times 4")
+        self.assertNotEqual(obj[1]['expression_data'], None)
+        self.assertEqual(obj[1]['description'],
+                         "max CPU greater than 10")
+        self.assertEqual(len(obj), 2)
+
+    def test_do_get_alarm_definitions_by_id(self):
+        res = mock.Mock()
+        req = mock.Mock()
 
         req_result = mock.Mock()
 
-        req_result.json.return_value = json.loads(response_str)
+        req_result.json.return_value = self.data
         req_result.status_code = 200
 
         with mock.patch.object(requests, 'get', return_value=req_result):
-            self.dispatcher_get.do_get_alarm_definitions(
+            self.dispatcher_get_by_id.do_get_alarm_definitions_by_id(
                 req, res, id="72df5ccb-ec6a-4bb4-a15c-939467ccdde0")
 
         # test that the response code is 200
@@ -191,30 +192,36 @@ class TestAlarmDefinitionDispatcher(base.BaseTestCase):
         res = mock.Mock()
         req_result = mock.Mock()
         req_result.status_code = 200
+        req_get_result = mock.Mock()
 
-        with mock.patch.object(requests, 'put', return_value=req_result):
-            with mock.patch.object(req.stream, 'read',
-                                   return_value="{ 'name': 'CPU usage test', "
-                                                "'alarm_actions': "
-                                                "'c60ec47e-5038-4bf1-9f95-"
-                                                "4046c6e9a719', "
-                                                "'undetermined_actions': "
-                                                "'c60ec47e-5038-4bf1-9t95-"
-                                                "4046c6e9a759', 'ok_actions':"
-                                                " 'c60ec47e-5038-4bf1-9f95-"
-                                                "4046cte9a759', "
-                                                "'match_by': 'hostname', "
-                                                "'severity': 'LOW', "
-                                                "'expression': "
-                                                "'max(cpu.usage{os=linux},"
-                                                "600)"
-                                                ">15', 'description': "
-                                                "'Max CPU 15'"
-                                                "}"
-                                   ):
-                self.dispatcher_put.do_put_alarm_definitions(
-                    req, res, id="72df5ccb-ec6a-4bb4-a15c-939467ccdde0")
-                self.assertEqual(res.status, getattr(falcon, 'HTTP_200'))
+        req_get_result.json.return_value = self.data
+        req_get_result.status_code = 200
+
+        with mock.patch.object(requests, 'get', return_value=req_get_result):
+            with mock.patch.object(requests, 'put', return_value=req_result):
+                with mock.patch.object(
+                        req.stream, 'read',
+                        return_value="{ 'name': 'CPU usage test', "
+                                     "'alarm_actions': "
+                                     "'c60ec47e-5038-4bf1-9f95-"
+                                     "4046c6e9a719', "
+                                     "'undetermined_actions': "
+                                     "'c60ec47e-5038-4bf1-9t95-"
+                                     "4046c6e9a759', 'ok_actions':"
+                                     " 'c60ec47e-5038-4bf1-9f95-"
+                                     "4046cte9a759', "
+                                     "'match_by': 'hostname', "
+                                     "'severity': 'LOW', "
+                                     "'expression': "
+                                     "'max(cpu.usage{os=linux},"
+                                     "600)"
+                                     ">15', 'description': "
+                                     "'Max CPU 15'"
+                                     "}"
+                ):
+                    self.dispatcher_put.do_put_alarm_definitions(
+                        req, res, id="8c85be40-bfcb-465c-b450-4eea670806a6")
+                    self.assertEqual(res.status, getattr(falcon, 'HTTP_200'))
 
     def test_do_delete_alarm_definitions(self):
         with mock.patch.object(es_conn.ESConnection, 'del_messages',

--- a/monasca/tests/v2/elasticsearch/test_alarmdefinitions.py
+++ b/monasca/tests/v2/elasticsearch/test_alarmdefinitions.py
@@ -83,11 +83,12 @@ class TestAlarmDefinitionDispatcher(base.BaseTestCase):
         req.query_string = 'name=CPU usage test&dimensions=os:linux'
         with mock.patch.object(es_conn.ESConnection, 'get_messages',
                                return_value=req_result):
-            self.dispatcher_get.do_get_alarm_definitions(req, res)
+            self.dispatcher_get.do_get_alarm_definitions_filtered(req, res)
 
         # test that the response code is 200
         self.assertEqual(res.status, getattr(falcon, 'HTTP_200'))
-        obj = json.loads(res.body)
+        json_result = json.loads(res.body)
+        obj = json_result['elements']
 
         # test that the first response object has the required properties
         self.assertEqual(obj[0]['id'],

--- a/monasca/tests/v2/elasticsearch/test_alarmdefinitions_data
+++ b/monasca/tests/v2/elasticsearch/test_alarmdefinitions_data
@@ -1,0 +1,82 @@
+{
+    "hits":{
+        "hits":[
+            {
+                "_score":1.0,
+                "_type":"alarmdefinitions",
+                "_id":"8c85be40-bfcb-465c-b450-4eea670806a6",
+                "_source":{
+                    "id":"8c85be40-bfcb-465c-b450-4eea670806a6",
+                    "name":"CPU usage test",
+                    "alarm_actions":
+                    "c60ec47e-5038-4bf1-9f95-4046c6e9a719",
+                    "undetermined_actions":
+                    "c60ec47e-5038-4bf1-9t95-4046c6e9a759",
+                    "ok_actions":
+                    "c60ec47e-5038-4bf1-9f95-4046cte9a759",
+                    "match_by":"hostname",
+                    "severity":"LOW",
+                    "expression":
+                    "max(cpu.usage{os=linux},600)>15",
+                    "expression_data": [
+                        {
+                            "function": "AVG",
+                            "metric_name": "cpu.avg.lt.10",
+                            "period": "6000",
+                            "threshold": "10",
+                            "periods": "1",
+                            "operator": "LTE",
+                            "dimensions": {
+                                "os": "linux"
+                            }
+                        }
+                    ],
+                    "description": "Max CPU 15"
+                },
+                "_index":"data_20150601000000"
+            },
+            {
+                "_score":1.0,
+                "_type":"alarmdefinitions",
+                "_id":"eb43fe12-b442-40b6-aab6-f34450cf90dd",
+                "_source":{
+                    "id":"eb43fe12-b442-40b6-aab6-f34450cf90dd",
+                    "name":"CPU usage in last 4 minutes",
+                    "alarm_actions":
+                    "c60ec47e-5038-4bf1-9f95-4046c6e9a719",
+                    "undetermined_actions":
+                    "c60ec47e-5038-4bf1-9t95-4046c6e9a759",
+                    "ok_actions":
+                    "c60ec47e-5038-4bf1-9f95-4046cte9a759",
+                    "match_by":"hostname",
+                    "severity":"LOW",
+                    "expression":
+                    "max(cpu.usage,60)>10 times 4",
+                    "expression_data": [
+                        {
+                            "function": "AVG",
+                            "metric_name": "cpu.avg.lt.10",
+                            "period": "6000",
+                            "threshold": "10",
+                            "periods": "1",
+                            "operator": "LTE",
+                            "dimensions": {
+                                "os": "linux"
+                            }
+                        }
+                    ],
+                    "description": "max CPU greater than 10"
+                },
+                "_index":"data_20150601000000"
+            }
+        ],
+        "total":2,
+        "max_score":1.0
+    },
+    "_shards":{
+        "successful":5,
+        "failed":0,
+        "total":5
+    },
+    "took":2
+}

--- a/monasca/tests/v2/elasticsearch/test_alarms.py
+++ b/monasca/tests/v2/elasticsearch/test_alarms.py
@@ -76,7 +76,8 @@ class TestAlarmDispatcher(base.BaseTestCase):
 
         # test that the response code is 200
         self.assertEqual(res.status, getattr(falcon, 'HTTP_200'))
-        obj = json.loads(res.body)
+        json_result = json.loads(res.body)
+        obj = json_result['elements']
 
         # test that the first response object has the required properties
         self.assertEqual(obj[0]['id'],

--- a/monasca/tests/v2/elasticsearch/test_alarms.py
+++ b/monasca/tests/v2/elasticsearch/test_alarms.py
@@ -1,0 +1,191 @@
+# Copyright 2015 Carnegie Mellon University
+#
+# Author: Shaunak Shatmanyu <shatmanyu@gmail.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import falcon
+import mock
+import os
+from oslo.config import fixture as fixture_config
+from oslotest import base
+
+from monasca.common import es_conn
+from monasca.v2.elasticsearch import alarms
+
+try:
+    import ujson as json
+except ImportError:
+    import json
+
+
+class TestAlarmDispatcher(base.BaseTestCase):
+
+    def setUp(self):
+        self.CONF = self.useFixture(fixture_config.Config()).conf
+        self.CONF.set_override('doc_type', 'fake', group='alarms')
+        self.CONF.set_override('uri', 'fake_es_uri', group='es_conn')
+        super(TestAlarmDispatcher, self).setUp()
+
+        self.dispatcher_get = (
+            alarms.AlarmDispatcher({}))
+
+        self.dispatcher_get_by_id = (
+            alarms.AlarmDispatcher({}))
+
+        self.dispatcher_put = (
+            alarms.AlarmDispatcher({}))
+
+        self.dispatcher_delete = (
+            alarms.AlarmDispatcher({}))
+
+        dir_path = os.path.dirname(os.path.realpath(__file__))
+        alarms_data_json = open(os.path.join(dir_path,
+                                             'test_alarms_data')
+                                ).read().replace('\n', '')
+        self.data = json.loads(alarms_data_json)
+
+    def test_initialization(self):
+        # test that the doc type of the es connection is fake
+        self.assertEqual(self.dispatcher_get._es_conn.doc_type, 'fake')
+
+        self.assertEqual(self.dispatcher_get._es_conn.uri, 'fake_es_uri/')
+
+    def test_do_get_alarms(self):
+        res = mock.Mock()
+        req = mock.Mock()
+        req_result = mock.Mock()
+        response_str = self.data
+        req_result.json.return_value = response_str
+        req_result.status_code = 200
+
+        req.query_string = 'metric_dimensions=hostname:h7,os:linux&state=OK'
+        with mock.patch.object(es_conn.ESConnection, 'get_messages',
+                               return_value=req_result):
+            self.dispatcher_get.do_get_alarms(req, res)
+
+        # test that the response code is 200
+        self.assertEqual(res.status, getattr(falcon, 'HTTP_200'))
+        obj = json.loads(res.body)
+
+        # test that the first response object has the required properties
+        self.assertEqual(obj[0]['id'],
+                         'cb71cc0f-ade1-433e-aa2d-22b12067cba0')
+        self.assertNotEqual(obj[0]['alarm_definition'], None)
+        self.assertNotEqual(obj[0]['metrics'], None)
+        self.assertEqual(obj[0]['state'], 'OK')
+        self.assertNotEqual(obj[0]['sub_alarms'], None)
+        self.assertEqual(obj[0]['created_timestamp'], '2015-06-17T18:43:21Z')
+        self.assertEqual(obj[0]['updated_timestamp'], '2015-06-17T18:43:27Z')
+        self.assertEqual(obj[0]['state_updated_timestamp'],
+                         '2015-06-17T18:43:27Z')
+
+        # test that the second response object has the required properties
+        self.assertEqual(obj[1]['id'],
+                         '1cfd25cb-f60d-4f5b-845f-8048c0678a8f')
+        self.assertNotEqual(obj[1]['alarm_definition'], None)
+        self.assertNotEqual(obj[1]['metrics'], None)
+        self.assertEqual(obj[1]['state'], 'OK')
+        self.assertNotEqual(obj[1]['sub_alarms'], None)
+        self.assertEqual(obj[1]['created_timestamp'], '2015-06-17T19:43:21Z')
+        self.assertEqual(obj[1]['updated_timestamp'], '2015-06-17T19:43:27Z')
+        self.assertEqual(obj[1]['state_updated_timestamp'],
+                         '2015-06-17T19:43:27Z')
+        self.assertEqual(len(obj), 2)
+
+    def test_do_get_alarms_by_id(self):
+        res = mock.Mock()
+        req = mock.Mock()
+
+        req_result = mock.Mock()
+
+        req_result.json.return_value = self.data
+        req_result.status_code = 200
+
+        with mock.patch.object(es_conn.ESConnection, 'get_message_by_id',
+                               return_value=req_result):
+            self.dispatcher_get_by_id.do_get_alarms_by_id(
+                req, res, id="d718fb26-d16d-4705-8f02-13a1468619c9")
+
+        # test that the response code is 200
+        self.assertEqual(res.status, getattr(falcon, 'HTTP_200'))
+        obj = json.loads(res.body)
+
+        # test that the response object has the required properties
+        self.assertEqual(obj[0]['id'],
+                         "d718fb26-d16d-4705-8f02-13a1468619c9")
+        self.assertNotEqual(obj[0]['metrics'], None)
+        self.assertEqual(obj[0]['state'], 'OK')
+        self.assertNotEqual(obj[0]['sub_alarms'], None)
+        self.assertEqual(obj[0]['created_timestamp'], '2015-06-17T18:43:21Z')
+        self.assertEqual(obj[0]['updated_timestamp'], '2015-06-17T18:43:27Z')
+        self.assertEqual(obj[0]['state_updated_timestamp'],
+                         '2015-06-17T18:43:27Z')
+        self.assertEqual(len(obj), 1)
+
+    def test_do_put_alarms(self):
+        req = mock.Mock()
+        res = mock.Mock()
+
+        req_result = ("{ 'id': 'd718fb26-d16d-4705-"
+                      "8f02-13a1468619c9', "
+                      "'links': ["
+                      "{"
+                      "'href': 'http://127.0.0.1:"
+                      "9090/v2.0/alarms/'"
+                      "'d718fb26-d16d-4705-8f02-"
+                      "13a1468619c9', "
+                      "'rel': 'self}], '"
+                      "'metrics': [{ "
+                      "'name': 'cpu.usage', "
+                      "'dimensions': { "
+                      "'hostname': "
+                      "'host7', 'os': 'linux' }}],"
+                      "'state': 'OK', "
+                      "'sub_alarms': [{"
+                      "'sub_alarm_expression': {"
+                      "'function': 'AVG', "
+                      "'metric_name': "
+                      "'cpu.usage', "
+                      "'period': '600', "
+                      "'threshold': '10', "
+                      "'periods': '1', "
+                      "'operator': 'LTE', "
+                      "'dimensions': {'os': "
+                      "'linux'}}, "
+                      "'current_values': "
+                      "[10.0498869723], "
+                      "'sub_alarm_state': 'OK'}], "
+                      "'created_timestamp': "
+                      "'2015-06-17T16:43:21Z', "
+                      "'state_updated_timestamp': "
+                      "'2015-06-17T16:43:27Z'"
+                      "}")
+
+        json_result = json.dumps(req_result)
+
+        with mock.patch.object(es_conn.ESConnection, 'put_messages',
+                               return_value=200):
+            with mock.patch.object(req.stream, 'read',
+                                   return_value=json_result):
+                self.dispatcher_put.do_put_alarms(
+                    req, res, id="d718fb26-d16d-4705-8f02-13a1468619c9")
+                self.assertEqual(res.status, getattr(falcon, 'HTTP_200'))
+
+    def test_do_delete_alarms(self):
+        with mock.patch.object(es_conn.ESConnection, 'del_messages',
+                               return_value=200):
+            res = mock.Mock()
+            self.dispatcher_delete.do_delete_alarms(
+                mock.Mock(), res, id="d718fb26-d16d-4705-8f02-13a1468619c9")
+            self.assertEqual(res.status, getattr(falcon, 'HTTP_200'))

--- a/monasca/tests/v2/elasticsearch/test_alarms_data
+++ b/monasca/tests/v2/elasticsearch/test_alarms_data
@@ -1,0 +1,116 @@
+{
+    "hits":{
+        "hits":[
+            {
+                "_score":1.0,
+                "_type":"alarms",
+                "_id":"cb71cc0f-ade1-433e-aa2d-22b12067cba0",
+                "_source":{
+                    "id":"cb71cc0f-ade1-433e-aa2d-22b12067cba0",
+                    "alarm-definition":{
+                        "alarm_actions":[
+                            "c60ec47e-5038-4bf1-9f95-4046c6e9a719"
+                        ],
+                        "undetermined_actions":[
+                            "c60ec47e-5038-4bf1-9t95-4046c6e9a759"
+                        ],
+                        "name": "Avg CPU percent greater than 10"
+                    },
+                    "metrics":[
+                        {
+                            "name": "cpu.usage",
+                            "dimensions": {
+                                "hostname": "h7",
+                                "os": "linux"
+                            }
+                        }
+                    ],
+                    "state":"OK",
+                    "sub_alarms":[
+                        {
+                            "sub_alarm_expression":{
+                                "function":"AVG",
+                                "metric_name":"cpu.usage",
+                                "period":"600",
+                                "threshold":"10",
+                                "periods":"1",
+                                "operator":"LTE",
+                                "dimensions":{
+                                    "os":"linux"
+                                }
+                            },
+                            "current_values":[
+                                13.0498869723
+                            ],
+                            "sub_alarm_state":"OK"
+                        }
+                    ],
+                    "created_timestamp":"2015-06-17T18:43:21Z",
+                    "updated_timestamp": "2015-06-17T18:43:27Z",
+                    "state_updated_timestamp":
+                        "2015-06-17T18:43:27Z"
+                },
+                "_index":"data_20150601000000"
+            },
+            {
+                "_score":1.0,
+                "_type":"alarms",
+                "_id":"1cfd25cb-f60d-4f5b-845f-8048c0678a8f",
+                "_source":{
+                    "id":"1cfd25cb-f60d-4f5b-845f-8048c0678a8f",
+                    "alarm-definition":{
+                        "alarm_actions":[
+                            "c60ec47e-5038-4bf1-9f95-4046c6e9a719"
+                        ],
+                        "undetermined_actions":[
+                            "c60ec47e-5038-4bf1-9t95-4046c6e9a759"
+                        ],
+                        "name":"Avg CPU percent greater than 10"
+                    },
+                    "metrics":[
+                        {
+                            "name": "cpu.usage",
+                            "dimensions": {
+                                "hostname": "h7",
+                                "os": "linux"
+                            }
+                        }
+                    ],
+                    "state":"OK",
+                    "sub_alarms":[
+                        {
+                            "sub_alarm_expression":{
+                                "function":"AVG",
+                                "metric_name":"cpu.usage",
+                                "period":"600",
+                                "threshold":"10",
+                                "periods":"1",
+                                "operator":"LTE",
+                                "dimensions":{
+                                    "os":"linux"
+                                }
+                            },
+                            "current_values":[
+                                13.0498869723
+                            ],
+                            "sub_alarm_state":"OK"
+                        }
+                    ],
+                    "created_timestamp":"2015-06-17T19:43:21Z",
+                    "updated_timestamp": "2015-06-17T19:43:27Z",
+                    "state_updated_timestamp":
+                        "2015-06-17T19:43:27Z"
+                },
+                "_index":"data_20150601000000"
+            }
+        ],
+        "total":2,
+        "max_score":1.0
+    },
+    "_shards":{
+        "successful":5,
+        "failed":0,
+        "total":5
+    },
+    "took":2
+}

--- a/monasca/v2/elasticsearch/alarmdefinitions.py
+++ b/monasca/v2/elasticsearch/alarmdefinitions.py
@@ -137,7 +137,7 @@ class AlarmDefinitionDispatcher(object):
                 }
             }
         else:
-            query = '*'
+            query = {}
         LOG.debug('Parsed Query: %s' % query)
         return query
 

--- a/monasca/v2/elasticsearch/alarmdefinitions.py
+++ b/monasca/v2/elasticsearch/alarmdefinitions.py
@@ -21,6 +21,8 @@ from oslo.config import cfg
 from stevedore import driver
 import uuid
 
+from monasca.common import alarm_expr_parser
+from monasca.common import alarm_expr_validator
 from monasca.common import es_conn
 from monasca.common import namespace
 from monasca.common import resource_api
@@ -100,6 +102,45 @@ class AlarmDefinitionDispatcher(object):
                 return obj.get('hits')
         return None
 
+    def _get_alarm_definitions_helper(self, query_string):
+        queries = []
+        field_string = 'alarmdefinitions.expression_data.dimensions.'
+        if query_string:
+            params = query_string.split('&')
+            for current_param in params:
+                current_param_split = current_param.split('=')
+                if current_param_split[0] == 'dimensions':
+                    current_dimension_split = (
+                        current_param_split[1].split(','))
+                    for current_dimension in current_dimension_split:
+                        current_dimen_data = current_dimension.split(':')
+                        queries.append({
+                            'query_string': {
+                                'default_field': (field_string +
+                                                  current_dimen_data[0]),
+                                'query': current_dimen_data[1]
+                            }
+                        })
+                else:
+                    queries.append({
+                        'query_string': {
+                            'default_field': current_param_split[0],
+                            'query': current_param_split[1]
+                        }
+                    })
+            LOG.debug(queries)
+            query = {
+                'query': {
+                    'bool': {
+                        'must': queries
+                    }
+                }
+            }
+        else:
+            query = '*'
+        LOG.debug('Parsed Query: %s' % query)
+        return query
+
     @resource_api.Restify('/v2.0/alarm-definitions/', method='post')
     def do_post_alarm_definitions(self, req, res):
         LOG.debug('Creating the alarm definitions')
@@ -111,18 +152,33 @@ class AlarmDefinitionDispatcher(object):
         id = str(uuid.uuid4())
         post_msg["id"] = id
         post_msg = AlarmDefinitionUtil.severityparsing(post_msg)
-        LOG.debug("Post Alarm Definition method: %s" % post_msg)
-        try:
-            es_res = self._es_conn.post_messages(json.dumps(post_msg), id)
-            LOG.debug('Query to ElasticSearch returned Status: %s' %
-                      es_res)
-            res.status = getattr(falcon, 'HTTP_%s' % es_res)
-        except Exception:
-            LOG.exception('Error occurred while handling '
-                          'Alarm Definition Post Request.')
+        post_msg_json = json.dumps(post_msg)
+        LOG.debug("Validating Alarm Definition Data: %s" % post_msg_json)
+
+        if alarm_expr_validator.is_valid_alarm_definition(post_msg_json):
+            LOG.debug("Post Alarm Definition method: %s" % post_msg)
+            try:
+                expression_parsed = (
+                    alarm_expr_parser.AlarmExprParser(post_msg["expression"]))
+                expression_data = expression_parsed.sub_alarm_expressions
+                expression_data_list = []
+                for temp in expression_data:
+                    expression_data_list.append(expression_data[temp])
+                post_msg["expression_data"] = expression_data_list
+                LOG.debug(post_msg)
+
+                es_res = self._es_conn.post_messages(json.dumps(post_msg), id)
+                LOG.debug('Query to ElasticSearch returned Status: %s' %
+                          es_res)
+                res.status = getattr(falcon, 'HTTP_%s' % es_res)
+            except Exception:
+                LOG.exception('Error occurred while handling '
+                              'Alarm Definition Post Request.')
+        else:
+            res.status = getattr(falcon, 'HTTP_400')
 
     @resource_api.Restify('/v2.0/alarm-definitions/{id}', method='get')
-    def do_get_alarm_definitions(self, req, res, id):
+    def do_get_alarm_definitions_by_id(self, req, res, id):
         LOG.debug('The alarm definitions GET request is received!')
         LOG.debug(id)
 
@@ -144,13 +200,15 @@ class AlarmDefinitionDispatcher(object):
                         "links": [{"rel": "self",
                                    "href": req.uri}],
                         "name": res_data["_source"]["name"],
-                        "description":res_data["_source"]["description"],
-                        "expression":res_data["_source"]["expression"],
-                        "severity":res_data["_source"]["severity"],
-                        "match_by":res_data["_source"]["match_by"],
-                        "alarm_actions":res_data["_source"]["alarm_actions"],
-                        "ok_actions":res_data["_source"]["ok_actions"],
-                        "undetermined_actions":res_data["_source"]
+                        "description": res_data["_source"]["description"],
+                        "expression": res_data["_source"]["expression"],
+                        "expression_data":
+                            res_data["_source"]["expression_data"],
+                        "severity": res_data["_source"]["severity"],
+                        "match_by": res_data["_source"]["match_by"],
+                        "alarm_actions": res_data["_source"]["alarm_actions"],
+                        "ok_actions": res_data["_source"]["ok_actions"],
+                        "undetermined_actions": res_data["_source"]
                         ["undetermined_actions"]}])
                     res.content_type = 'application/json;charset=utf-8'
         except Exception:
@@ -160,14 +218,57 @@ class AlarmDefinitionDispatcher(object):
     @resource_api.Restify('/v2.0/alarm-definitions/{id}', method='put')
     def do_put_alarm_definitions(self, req, res, id):
         LOG.debug("Put the alarm definitions with id: %s" % id)
+
+        es_res = self._es_conn.get_message_by_id(id)
+        LOG.debug('Query to ElasticSearch returned Status: %s' %
+                  es_res.status_code)
+        es_res = self._get_alarm_definitions_response(es_res)
+        LOG.debug('Query to ElasticSearch returned: %s' % es_res)
+
+        original_data = {}
         try:
+            if es_res["hits"]:
+                res_data = es_res["hits"][0]
+                if res_data:
+                    original_data = json.dumps({
+                        "id": id,
+                        "name": res_data["_source"]["name"],
+                        "description": res_data["_source"]["description"],
+                        "expression": res_data["_source"]["expression"],
+                        "expression_data":
+                            res_data["_source"]["expression_data"],
+                        "severity": res_data["_source"]["severity"],
+                        "match_by": res_data["_source"]["match_by"],
+                        "alarm_actions": res_data["_source"]["alarm_actions"],
+                        "ok_actions": res_data["_source"]["ok_actions"],
+                        "undetermined_actions": res_data["_source"]
+                        ["undetermined_actions"]})
+
             msg = req.stream.read()
             put_msg = ast.literal_eval(msg)
             put_msg = AlarmDefinitionUtil.severityparsing(put_msg)
-            es_res = self._es_conn.put_messages(json.dumps(put_msg), id)
-            LOG.debug('Query to ElasticSearch returned Status: %s' %
-                      es_res)
-            res.status = getattr(falcon, 'HTTP_%s' % es_res)
+
+            expression_parsed = (
+                alarm_expr_parser.AlarmExprParser(put_msg["expression"])
+            )
+            expression_data = expression_parsed.sub_alarm_expressions
+            expression_data_list = []
+            for temp in expression_data:
+                expression_data_list.append(expression_data[temp])
+            put_msg["expression_data"] = expression_data_list
+
+            put_msg_json = json.dumps(put_msg)
+            LOG.debug("Alarm Definition Put Data: %s" % put_msg_json)
+
+            if alarm_expr_validator.is_valid_update_alarm_definition(
+                    original_data, put_msg_json):
+                es_res = self._es_conn.put_messages(put_msg_json, id)
+                LOG.debug('Query to ElasticSearch returned Status: %s' %
+                          es_res)
+                res.status = getattr(falcon, 'HTTP_%s' % es_res)
+            else:
+                res.status = getattr(falcon, 'HTTP_400')
+                LOG.debug("Validating Alarm Definition Failed !!")
         except Exception:
             LOG.exception('Error occurred while handling Alarm '
                           'Definition Put Request.')
@@ -183,3 +284,58 @@ class AlarmDefinitionDispatcher(object):
         except Exception:
             LOG.exception('Error occurred while handling Alarm '
                           'Definition Delete Request.')
+
+    @resource_api.Restify('/v2.0/alarm-definitions', method='get')
+    def do_get_alarm_definitions(self, req, res):
+        LOG.debug('The alarm definitions GET request is received!')
+
+        query_string = req.query_string
+        LOG.debug('Request Query String: %s' % query_string)
+
+        params = self._get_alarm_definitions_helper(query_string)
+        LOG.debug('Query Data: %s' % params)
+
+        es_res = self._es_conn.get_messages(params)
+        res.status = getattr(falcon, 'HTTP_%s' % es_res.status_code)
+        LOG.debug('Query to ElasticSearch returned Status: %s' %
+                  es_res.status_code)
+
+        es_res = self._get_alarm_definitions_response(es_res)
+        LOG.debug('Query to ElasticSearch returned: %s' % es_res)
+
+        res.body = ''
+        try:
+            if es_res["hits"]:
+                res_data = es_res["hits"]
+                res.body = '['
+                for current_alarm in res_data:
+                    if current_alarm:
+                        res.body += json.dumps({
+                            "id": current_alarm["_source"]["id"],
+                            "links": [{"rel": "self",
+                                       "href": req.uri}],
+                            "name": current_alarm["_source"]["name"],
+                            "description":
+                                current_alarm["_source"]["description"],
+                            "expression":
+                                current_alarm["_source"]["expression"],
+                            "expression_data":
+                                current_alarm["_source"]["expression_data"],
+                            "severity":
+                                current_alarm["_source"]["severity"],
+                            "match_by":
+                                current_alarm["_source"]["match_by"],
+                            "alarm_actions":
+                                current_alarm["_source"]["alarm_actions"],
+                            "ok_actions":
+                                current_alarm["_source"]["ok_actions"],
+                            "undetermined_actions":
+                                current_alarm["_source"]
+                            ["undetermined_actions"]})
+                        res.body += ','
+                res.body = res.body[:-1]
+                res.body += ']'
+                res.content_type = 'application/json;charset=utf-8'
+        except Exception:
+            LOG.exception('Error occurred while handling Alarm '
+                          'Definitions Get Request.')

--- a/monasca/v2/elasticsearch/alarms.py
+++ b/monasca/v2/elasticsearch/alarms.py
@@ -115,7 +115,7 @@ class AlarmDispatcher(object):
                 }
             }
         else:
-            query = '*'
+            query = {}
         LOG.debug('Parsed Query: %s' % query)
         return query
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,6 +47,7 @@ monasca.dispatcher =
     versions = monasca.v2.elasticsearch.versions:VersionDispatcher
     alarmdefinitions = monasca.v2.elasticsearch.alarmdefinitions:AlarmDefinitionDispatcher
     notificationmethods = monasca.v2.elasticsearch.notificationmethods:NotificationMethodDispatcher
+	alarms = monasca.v2.elasticsearch.alarms:AlarmDispatcher
 
 monasca.index.strategy =
     timed = monasca.microservice.timed_strategy:TimedStrategy


### PR DESCRIPTION
The code has been rebased and verified with tox -e pep8, tox -e py27 & tox -e cover executions.

Alarms API v1.1 Check-In contains Read, Update & Delete operations for Alarms in Monasca Service.

Also modified the AlarmDefinitions operations as listed below.

Tested with basic Test Scenarios as given in referred Specification
document.

The four basic operations for Alarms are given as:
1. Get Alarms for given parameters (List Alarms)
2. Get Alarms by ID
3. Update Alarms
4. Delete Alarms

The additional modified operations for Alarm Definition are given as:
1. Get Alarm Definitions (List Alarm Definitions)
2. Revised Put Alarm Definition based on alarm parser
3. Revised Post Alarm Definition based on alarm validation