### PR TITLE
Anomaly prototype

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,5 @@ coverage.xml
 # Sphinx documentation
 docs/_build/
 
+
+.idea/

--- a/etc/monasca-anomaly-engine.conf
+++ b/etc/monasca-anomaly-engine.conf
@@ -1,0 +1,55 @@
+[DEFAULT]
+#logging, make sure that the user under whom the server runs has permission
+#to write to the directory.
+log_file=monasca-anomaly-engine.log
+log_dir=/var/log/monasca/
+log_level=DEBUG
+default_log_levels = monasca=DEBUG
+
+service = notification_engine
+threads = 3
+
+[anomalyengine]
+topic = metrics
+processor = ks_anomaly_processor
+
+[metrics]
+names = cpu.user_perc, cpu.system_perc
+metric_name_suffix = .anomaly_score
+
+[ks]
+num_processors = 2
+reference_duration = 3600
+probe_duration = 600
+ks_d = 0.5
+min_samples = 15
+
+[kafka_opts]
+#The endpoint to the kafka server, you can have multiple servers listed here
+#for example:
+#uri = 10.100.41.114:9092,10.100.41.115:9092,10.100.41.116:9092
+uri = 192.168.1.191:9092
+
+#consumer group name
+group = datapoints_group
+
+#how many times to try when error occurs
+max_retry = 1
+
+#wait time between tries when kafka goes down
+wait_time = 1
+
+#use synchronized or asynchronized connection to kafka
+async = False
+
+#send messages in bulk or send messages one by one.
+compact = False
+
+#How many partitions this connection should listen messages on, this
+#parameter is for reading from kafka. If listens on multiple partitions,
+#For example, if the client should listen on partitions 1 and 3, then the
+#configuration should look like the following:
+#   partitions = 1
+#   partitions = 3
+#default to listen on partition 0.
+partitions = 0

--- a/monasca/microservice/anomaly_engine.py
+++ b/monasca/microservice/anomaly_engine.py
@@ -1,0 +1,89 @@
+# Copyright 2015 Carnegie Mellon University
+#
+# Author: Han Chen <hanc@andrew.cmu.edu>
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import ast
+from oslo.config import cfg
+from stevedore import driver
+from monasca.common import kafka_conn
+from monasca.common import namespace
+from monasca.openstack.common import log
+from monasca.openstack.common import service as os_service
+
+ANOMALY_ENGINE_OPTS = [
+    cfg.StrOpt('topic',
+               default='metrics',
+               help='The topic that messages will be retrieved from.'),
+    cfg.StrOpt('processor',
+               default='ks_anomaly_processor',
+               help=('The message processer to load to process the message.'
+                     'If the message does not need to be process anyway,'
+                     'leave the default')),
+]
+
+cfg.CONF.register_opts(ANOMALY_ENGINE_OPTS, group="anomalyengine")
+
+LOG = log.getLogger(__name__)
+
+
+class AnomalyEngine(os_service.Service):
+
+    def __init__(self, threads=1000):
+        super(AnomalyEngine, self).__init__(threads)
+        self._kafka_conn = kafka_conn.KafkaConnection(
+            cfg.CONF.anomalyengine.topic)
+
+        if cfg.CONF.anomalyengine.processor:
+            self.ks_anomaly_processor = driver.DriverManager(
+                namespace.PROCESSOR_NS,
+                cfg.CONF.anomalyengine.processor,
+                invoke_on_load=True,
+                invoke_kwds={}).driver
+            LOG.debug(dir(self.ks_anomaly_processor))
+        else:
+            self.ks_anomaly_processor = None
+
+    def start(self):
+        while True:
+            try:
+                for msg in self._kafka_conn.get_messages():
+                    if msg and msg.message:
+                        LOG.debug("Message received for alarm: " + msg.message.value)
+                        msg_value = msg.message.value
+                        if msg_value:
+                            '''msg_value's format is:
+                            {
+                            'name': 'cpu.user_perc',
+                            'dimensions': {
+                                'k0': 'v0',
+                                'hostname': 'Ibmserver'
+                            },
+                            'timestamp': 1405630174123,
+                            'value': 20,
+                            'dimensions_hash': ef3fb07027653934898bc9e3b908c29b
+                            }
+                            '''
+                            # convert to dict
+                            dict_metric = ast.literal_eval(msg_value)
+                            (self.ks_anomaly_processor.
+                                handle_prediction(dict_metric))
+                # if autocommit is set, this will be a no-op call.
+                self._kafka_conn.commit()
+            except Exception:
+                LOG.exception('Error occurred while handling kafka messages.')
+
+    def stop(self):
+        self._kafka_conn.close()
+        super(AnomalyEngine, self).stop()

--- a/monasca/microservice/ks_anomaly_processor.py
+++ b/monasca/microservice/ks_anomaly_processor.py
@@ -1,0 +1,125 @@
+# Copyright (c) 2014 Hewlett-Packard Development Company, L.P.
+# Copyright 2015 Carnegie Mellon University
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import ast
+import collections
+import scipy
+import statsmodels.api as sm
+import time
+from monasca.common import kafka_conn
+from monasca.openstack.common import log
+from oslo.config import cfg
+
+try:
+    import ujson as json
+except ImportError:
+    import json
+
+LOG = log.getLogger(__name__)
+METRIC_NAME_SUFFIXES = ['.predicted', '.anomaly_score', '.anomaly_likelihood']
+
+KS_ANOMALY_PROCESSOR_OPTS = [
+    cfg.StrOpt('topic',
+               default='metrics',
+               help='The topic that messages will be retrieved from.'),
+    cfg.StrOpt('names',
+               default='cpu.user_perc, cpu.system_perc',
+               help='metric names'),
+    cfg.StrOpt('metric_name_suffix',
+               default='.anomaly_score',
+               help='the suffix to metric names that indicates it is processed'),
+    cfg.IntOpt('reference_duration',
+               default=3600,
+               help=''),
+    cfg.IntOpt('probe_duration',
+               default=600,
+               help=''),
+    cfg.FloatOpt('ks_d',
+               default=0.5),
+    cfg.IntOpt('min_samples',
+               default=15),
+]
+
+cfg.CONF.register_opts(KS_ANOMALY_PROCESSOR_OPTS, group="ksanomalyprocess")
+
+class KsAnomalyProcessor(object):
+    def __init__(self):
+        LOG.debug('initializing KsAnomalyProcessor!')
+        super(KsAnomalyProcessor, self).__init__()
+        self._reference_duration = cfg.CONF.ksanomalyprocess.reference_duration
+        self._probe_duration = cfg.CONF.ksanomalyprocess.probe_duration
+        self._ks_d = cfg.CONF.ksanomalyprocess.ks_d
+        self._min_samples = cfg.CONF.ksanomalyprocess.min_samples
+        self._metric_name_suffix = cfg.CONF.ksanomalyprocess.metric_name_suffix
+        self._metric_names = cfg.CONF.ksanomalyprocess.names
+        self._timeseries = {}
+        self._kafka_conn = kafka_conn.KafkaConnection(
+            cfg.CONF.ksanomalyprocess.topic)
+
+    def _send_predictions(self, metric_id, metric):
+        if metric_id not in self._timeseries:
+            self._timeseries[metric_id] = collections.deque(maxlen=256)
+
+        time_series = self._timeseries[metric_id]
+        time_series.append((metric['timestamp'], metric['value']))
+        result = self._ks_test(time_series)
+        metric_name = metric['name']
+        metric['name'] = metric_name + '.ks.anomaly_score'
+        metric['value'] = result
+        processed_metic = json.dumps(metric)
+
+        self._kafka_conn.send_messages(processed_metic)
+
+    def _ks_test(self, timeseries):
+        """
+        A timeseries is anomalous if 2 sample Kolmogorov-Smirnov test indicates
+        that data distribution for last 10 minutes is different from last hour.
+        It produces false positives on non-stationary series so Augmented
+        Dickey-Fuller test applied to check for stationarity.
+        """
+        now = int(time.time())
+        reference_start_time = now - self._reference_duration
+        probe_start_time = now - self._probe_duration
+
+        reference = scipy.array([x[1] for x in timeseries if x[0] >= reference_start_time and
+                                 x[0] < probe_start_time])
+        probe = scipy.array([x[1] for x in timeseries if x[0] >= probe_start_time])
+
+        if reference.size < self._min_samples or probe.size < self._min_samples:
+            return 0.0
+
+        ks_d, ks_p_value = scipy.stats.ks_2samp(reference, probe)
+
+        if ks_p_value < 0.05 and ks_d > self._ks_d:
+            results = sm.tsa.stattools.adfuller(reference)
+            pvalue = results[1]
+            if pvalue < 0.05:
+                return 1.0
+
+        return 0.0
+
+    def handle_prediction(self, dict_metric):
+        metric_name = dict_metric['name']
+
+        if metric_name not in self._metric_names:
+            return
+
+        # exclude the processed metrics
+        if any(suffix in metric_name for suffix in self._metric_name_suffix):
+            return
+        # dimension_hash is used to group same type of metrics
+        metric_id = dimensions_hash = dict_metric['dimensions_hash']
+        self._send_predictions(metric_id, dict_metric)

--- a/monasca/tests/microservice/test_ks_anomaly_processor.py
+++ b/monasca/tests/microservice/test_ks_anomaly_processor.py
@@ -1,0 +1,96 @@
+# Copyright 2015 Carnegie Mellon University
+#
+# Author: Han Chen <hanc@andrew.cmu.edu>
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import ast
+import falcon
+import mock
+from monasca.common import kafka_conn
+from oslo.config import fixture as fixture_config
+from oslotest import base
+from monasca.microservice import ks_anomaly_processor
+
+import json
+
+class TestParamUtil(base.BaseTestCase):
+
+    def setUp(self):
+        super(TestParamUtil, self).setUp()
+        self.req = mock.Mock()
+
+class TestKsAnomalyProcessor(base.BaseTestCase):
+
+    def setUp(self):
+        self.CONF = self.useFixture(fixture_config.Config()).conf
+        self.CONF.ksanomalyprocess.topic = 'metrics'
+        self.CONF.ksanomalyprocess.reference_duration = 3600
+        self.CONF.ksanomalyprocess.probe_duration = 600
+        self.CONF.ksanomalyprocess.ks_d = 0.5
+        self.CONF.ksanomalyprocess.min_samples = 15
+        self.CONF.ksanomalyprocess.metric_name_suffix = '.anomaly_score'
+        self.CONF.ksanomalyprocess.names = 'cpu.user_perc'
+        self.kap = ks_anomaly_processor.KsAnomalyProcessor()
+        super(TestKsAnomalyProcessor, self).setUp()
+
+    def test_initialization(self):
+        # test that the doc type of the es connection is fake
+        self.assertEqual(self.kap._reference_duration, 3600)
+        self.assertEqual(self.kap._probe_duration, 600)
+        self.assertEqual(self.kap._ks_d, 0.5)
+        self.assertEqual(self.kap._min_samples, 15)
+        self.assertEqual(self.kap._metric_name_suffix, '.anomaly_score')
+        self.assertEqual(self.kap._metric_names, 'cpu.user_perc')
+
+    def test_handle_prediction(self):
+        with mock.patch.object(ks_anomaly_processor.KsAnomalyProcessor,
+                               '_send_predictions',
+                               return_value=""):
+            msg = ast.literal_eval(
+                '{"name": "cpu.user_perc", '
+                '"dimensions": {'
+                '"k0": "v0",'
+                '"hostname": "Ibmserver"}'
+                '"timestamp", 1405630174123,'
+                '"value": 20,'
+                '"dimensions_hash": "ef3fb07027653934898bc9e3b908c29b"}')
+
+            self.kap.handle_notification_msg(msg)
+
+    def test__send_predictions(self):
+        with mock.patch.object(kafka_conn.KafkaConnection,
+                               'send_messages',
+                               return_value=200):
+            with mock.patch.object(ks_anomaly_processor.KsAnomalyProcessor,
+                                   '_ks_test',
+                                   return_value=""):
+                with mock.patch.object(ks_anomaly_processor.KsAnomalyProcessor,
+                                       '_ks_test',
+                                       return_value=0):
+                    metric_id = 'ef3fb07027653934898bc9e3b908c29b'
+                    metric = ast.literal_eval(
+                        '{"name": "cpu.user_perc", '
+                        '"dimensions": {'
+                        '"k0": "v0",'
+                        '"hostname": "Ibmserver"}'
+                        '"timestamp", 1405630174123,'
+                        '"value": 20,'
+                        '"dimensions_hash": "ef3fb07027653934898bc9e3b908c29b"}')
+                    self.kap._send_predictions(metric_id, metric)
+                    self.assertEqual(self._metric_names, 'cpu.user_perc')
+                    self.assertEqual(list(self.kap._timeseries)[0][0], '1405630174123')
+                    self.assertEqual(list(self.kap._timeseries)[0][1], 20)
+                    self.assertEqual(metric['name'], 'cpu.user_perc.ks.anomaly_score')
+                    self.assertEqual(metric['value'], 0)
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,3 +34,6 @@ ujson>=1.33
 babel
 eventlet
 pyparsing
+statsmodels
+NumPy>= 1.6
+SciPy>= 0.10

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,6 +32,7 @@ data_files =
         etc/metrics-persister.conf
         etc/alarms-persister.conf
         etc/monasca-notification.conf
+        etc/monasca-anomaly-engine.conf
 
 [entry_points]
 console_scripts =
@@ -41,6 +42,7 @@ monasca.microservice =
     es_persister = monasca.microservice.es_persister:ESPersister
     threshold_engine = monasca.microservice.threshold_engine:ThresholdEngine
     notification_engine = monasca.microservice.notification_engine:NotificationEngine
+    anomaly_engine = monasca.microservice.anomaly_engine:AnomalyEngine
 
 monasca.dispatcher =
     metrics = monasca.v2.elasticsearch.metrics:MetricDispatcher
@@ -56,6 +58,7 @@ monasca.message.processor =
     metrics_msg_fixer = monasca.microservice.metrics_fixer:MetricsFixer
     notification_processor = monasca.microservice.notification_processor:NotificationProcessor
     threshold_processor = monasca.microservice.threshold_processor:NotificationProcessor
+    ks_anomaly_processor = monasca.microservice.ks_anomaly_processor:KsAnomalyProcessor
 
 paste.filter_factory =
     login = monasca.middleware.login:filter_factory


### PR DESCRIPTION
Tong,

Here's the info of this pull:
Code anomaly engine and processor with ks algorithm

One issue is scipy cannot be installed in virtulenv, so tox cannot run the unit test.
Although  'import scipy' works on ubuntu after running 'sudo apt-get install python-numpy python-scipy', but it gives error for tox -e py27 :

  File "monasca/microservice/ks_anomaly_processor.py", line 19, in <module>
    import scipy
ImportError: No module named scipy

If you have any successful installation steps, please let us know.

Thanks,
Han

