### PR TITLE
use received timestamp for processing metrics in thresh engine

### DIFF
--- a/monasca/microservice/notification_processor.py
+++ b/monasca/microservice/notification_processor.py
@@ -55,7 +55,7 @@ class NotificationProcessor(object):
                 #   },
                 #   "state_updated_timestamp": 1432672915,
                 #   "state": "ALARM",
-                #   "alarm-definition": {
+                #   "alarm_definition": {
                 #     "alarm_actions": [
                 #       "c60ec47e-5038-4bf1-9f95-4046c6e9a759"
                 #     ],
@@ -90,12 +90,12 @@ class NotificationProcessor(object):
 
                 actions = []
                 if state == 'ALARM':
-                    actions = dict_msg["alarm-definition"]["alarm_actions"]
+                    actions = dict_msg["alarm_definition"]["alarm_actions"]
                 if state == 'OK':
-                    actions = dict_msg["alarm-definition"]["ok_actions"]
+                    actions = dict_msg["alarm_definition"]["ok_actions"]
                 if state == 'UNDETERMINED':
                     actions = dict_msg[
-                        "alarm-definition"]["undetermined_actions"]
+                        "alarm_definition"]["undetermined_actions"]
 
                 addresses = []
                 types = []
@@ -127,5 +127,5 @@ class NotificationProcessor(object):
                 self._email_sender.send_emails(
                     self.email_addresses,
                     "Alarm from Monasca:" + name + "-" +
-                    dict_msg["alarm-definition"]["description"],
+                    dict_msg["alarm_definition"]["description"],
                     str(dict_msg))

--- a/monasca/microservice/threshold_processor.py
+++ b/monasca/microservice/threshold_processor.py
@@ -250,7 +250,7 @@ class ThresholdProcessor(object):
                 data_list = temp['data'][expr.fmtd_sub_expr_str]
                 data_list['metrics'].append(
                     {'value': float(data['value']),
-                     'timestamp': float(data['timestamp'])})
+                     'timestamp': tu.utcnow_ts()})
                 return True
             else:
                 return False
@@ -302,7 +302,7 @@ class ThresholdProcessor(object):
         alarm = {}
         id = str(uuid.uuid4())
         alarm['id'] = id
-        alarm['alarm_definition_id'] = self.alarm_definition['id']
+        alarm['alarm_definition'] = self.alarm_definition
         alarm['metrics'] = self.related_metrics[name]
         alarm['state'] = self.expr_data_queue[name]['state']
         alarm['reason'] = reasons[alarm['state']]

--- a/monasca/tests/microservice/test_notification_processor.py
+++ b/monasca/tests/microservice/test_notification_processor.py
@@ -80,7 +80,7 @@ class TestNotificationProcessor(tests.BaseTestCase):
              "'dimensions': {'key2': 'value2', 'key1': 'value1'}},"
              "'state_updated_timestamp': 1432672915,"
              "'state': 'ALARM',"
-             "'alarm-definition':"
+             "'alarm_definition':"
              "{'alarm_actions': ['c60ec47e-5038-4bf1-9f95-4046c6e9a759'],"
              "'undetermined_actions': "
              "['c60ec47e-5038-4bf1-9f95-4046c6e9a759'],"

--- a/monasca/tests/microservice/test_threshold_processor.py
+++ b/monasca/tests/microservice/test_threshold_processor.py
@@ -15,6 +15,7 @@
 # under the License.
 
 import json
+import mock
 from monasca.microservice import threshold_processor as processor
 from monasca.openstack.common import log
 from monasca.openstack.common import timeutils as tu
@@ -94,7 +95,10 @@ class TestThresholdProcessor(tests.BaseTestCase):
         # send metrics to the processor
         metrics_list = self.util.get_metrics("metrics_utf8")
         for metrics in metrics_list:
-            tp.process_metrics(metrics)
+            timestamp = json.loads(metrics)['timestamp']
+            with mock.patch.object(tu, 'utcnow_ts',
+                                   return_value=timestamp):
+                tp.process_metrics(metrics)
         # manually call the function to update alarms
         alarms = tp.process_alarms()
         print (alarms)
@@ -106,7 +110,10 @@ class TestThresholdProcessor(tests.BaseTestCase):
         tp = processor.ThresholdProcessor(ad)
         metrics_list = self.util.get_metrics("metrics_periods_0")
         for metrics in metrics_list:
-            tp.process_metrics(metrics)
+            timestamp = json.loads(metrics)['timestamp']
+            with mock.patch.object(tu, 'utcnow_ts',
+                                   return_value=timestamp):
+                tp.process_metrics(metrics)
         alarms = tp.process_alarms()
         print (alarms)
         self.assertEqual(1, len(alarms))
@@ -115,7 +122,10 @@ class TestThresholdProcessor(tests.BaseTestCase):
         tp = processor.ThresholdProcessor(ad)
         metrics_list = self.util.get_metrics("metrics_periods_1")
         for metrics in metrics_list:
-            tp.process_metrics(metrics)
+            timestamp = json.loads(metrics)['timestamp']
+            with mock.patch.object(tu, 'utcnow_ts',
+                                   return_value=timestamp):
+                tp.process_metrics(metrics)
         alarms = tp.process_alarms()
         print (alarms)
         self.assertEqual(1, len(alarms))
@@ -125,7 +135,10 @@ class TestThresholdProcessor(tests.BaseTestCase):
         tp = processor.ThresholdProcessor(ad)
         metrics_list = self.util.get_metrics("metrics_periods_2")
         for metrics in metrics_list:
-            tp.process_metrics(metrics)
+            timestamp = json.loads(metrics)['timestamp']
+            with mock.patch.object(tu, 'utcnow_ts',
+                                   return_value=timestamp):
+                tp.process_metrics(metrics)
         alarms = tp.process_alarms()
         print (alarms)
         self.assertEqual(0, len(alarms))
@@ -135,7 +148,10 @@ class TestThresholdProcessor(tests.BaseTestCase):
         tp = processor.ThresholdProcessor(ad)
         metrics_list = self.util.get_metrics("metrics_match_by")
         for metrics in metrics_list:
-            tp.process_metrics(metrics)
+            timestamp = json.loads(metrics)['timestamp']
+            with mock.patch.object(tu, 'utcnow_ts',
+                                   return_value=timestamp):
+                tp.process_metrics(metrics)
         alarms = tp.process_alarms()
         print (alarms)
         self.assertEqual(3, len(alarms))
@@ -148,7 +164,10 @@ class TestThresholdProcessor(tests.BaseTestCase):
         tp = processor.ThresholdProcessor(ad)
         metrics_list = self.util.get_metrics("metrics_multi_match_by")
         for metrics in metrics_list:
-            tp.process_metrics(metrics)
+            timestamp = json.loads(metrics)['timestamp']
+            with mock.patch.object(tu, 'utcnow_ts',
+                                   return_value=timestamp):
+                tp.process_metrics(metrics)
         alarms = tp.process_alarms()
         print (alarms)
         self.assertEqual(3, len(alarms))
@@ -158,7 +177,10 @@ class TestThresholdProcessor(tests.BaseTestCase):
         tp = processor.ThresholdProcessor(ad)
         metrics_list = self.util.get_metrics("metrics_more_dimensions")
         for metrics in metrics_list:
-            tp.process_metrics(metrics)
+            timestamp = json.loads(metrics)['timestamp']
+            with mock.patch.object(tu, 'utcnow_ts',
+                                   return_value=timestamp):
+                tp.process_metrics(metrics)
         alarms = tp.process_alarms()
         print (alarms)
         self.assertEqual(1, len(alarms))
@@ -171,7 +193,10 @@ class TestThresholdProcessor(tests.BaseTestCase):
         tp = processor.ThresholdProcessor(ad)
         metrics_list = self.util.get_metrics("metrics_match_by_wrong")
         for metrics in metrics_list:
-            tp.process_metrics(metrics)
+            timestamp = json.loads(metrics)['timestamp']
+            with mock.patch.object(tu, 'utcnow_ts',
+                                   return_value=timestamp):
+                tp.process_metrics(metrics)
         alarms = tp.process_alarms()
         print (alarms)
         self.assertEqual(1, len(alarms))
@@ -196,7 +221,10 @@ class TestThresholdProcessor(tests.BaseTestCase):
         tp = processor.ThresholdProcessor(ad)
         metrics_list = self.util.get_metrics("metrics_match_by")
         for metrics in metrics_list:
-            tp.process_metrics(metrics)
+            timestamp = json.loads(metrics)['timestamp']
+            with mock.patch.object(tu, 'utcnow_ts',
+                                   return_value=timestamp):
+                tp.process_metrics(metrics)
         alarms = tp.process_alarms()
         print (alarms)
         ad = self.util.get_alarm_def("alarm_def_match_by_update")

--- a/monasca/tests/v2/elasticsearch/test_alarms_data
+++ b/monasca/tests/v2/elasticsearch/test_alarms_data
@@ -7,7 +7,7 @@
                 "_id":"cb71cc0f-ade1-433e-aa2d-22b12067cba0",
                 "_source":{
                     "id":"cb71cc0f-ade1-433e-aa2d-22b12067cba0",
-                    "alarm-definition":{
+                    "alarm_definition":{
                         "alarm_actions":[
                             "c60ec47e-5038-4bf1-9f95-4046c6e9a719"
                         ],
@@ -58,7 +58,7 @@
                 "_id":"1cfd25cb-f60d-4f5b-845f-8048c0678a8f",
                 "_source":{
                     "id":"1cfd25cb-f60d-4f5b-845f-8048c0678a8f",
-                    "alarm-definition":{
+                    "alarm_definition":{
                         "alarm_actions":[
                             "c60ec47e-5038-4bf1-9f95-4046c6e9a719"
                         ],

--- a/monasca/v2/elasticsearch/alarms.py
+++ b/monasca/v2/elasticsearch/alarms.py
@@ -155,7 +155,7 @@ class AlarmDispatcher(object):
                             "links": [{"rel": "self",
                                        "href": req.uri}],
                             "alarm_definition": current_alarm["_source"]
-                            ["alarm-definition"],
+                            ["alarm_definition"],
                             "metrics": current_alarm["_source"]["metrics"],
                             "state": current_alarm["_source"]["state"],
                             "sub_alarms": current_alarm["_source"]


### PR DESCRIPTION
1. use the solution mentioned yesterday, to use received time as metrics timestamp.
2. in alarm message, still give the whole alarm-definition, instead of alarm_definition_id,
notification engine need the whole alarm def.
patch for noti part will come soon.